### PR TITLE
Add Better Auth integration with Drizzle ORM

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,23 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+Hairfluencer is a Bun-driven Turborepo. `apps/web` hosts the Next.js 15 site (`app/` routes, `public/` assets). `apps/mobile` contains the Expo Router client (`app/` screens, `components/` shared UI, `assets/` media). `apps/api` is a Bun + Hono service; route handlers sit in `src/`, database logic in `src/db`, and migrations in `src/db/migrations`. Shared lint and TypeScript presets live in `packages/eslint-config` and `packages/typescript-config`. Place reusable modules in `packages/` rather than duplicating inside apps.
+
+## Build, Test, and Development Commands
+- `bun install` (root) boots all workspaces.
+- `bun run dev` runs `turbo run dev`; limit scope with `bunx turbo run dev --filter=apps/web`, `apps/mobile`, or `apps/api`.
+- `bun run build` executes every build pipeline and emits `.next/`, Expo, and API artifacts.
+- `bun run lint`, `bun run check-types`, and `bun run format` must succeed before a PR.
+- API migrations: `bunx drizzle-kit generate --config apps/api/drizzle.config.ts`, then commit the generated files.
+
+## Coding Style & Naming Conventions
+TypeScript is mandatory. Run `bun run format`; Prettier enforces two-space indentation and semicolons. Use PascalCase for React components/screens, camelCase for hooks and helpers, and UPPER_SNAKE_CASE for environment keys. Keep Tailwind class lists readable and colocate feature logic with the folder it supports. ESLint flat configs from `@repo/eslint-config` are required; if you disable a rule, leave a short reason. Resolve `turbo/no-undeclared-env-vars` warnings before merging.
+
+## Testing Guidelines
+A shared test runner is not configured yet. Add package-level scripts (`"test": "bun test"`, `"test": "vitest"`) and register them in `turbo.json` when adding automated coverage. Store unit tests beside the code (`apps/api/src/**/__tests__`, `apps/web/app/**/__tests__`). Capture critical flows—API routes, Expo navigation—in integration tests or document the manual QA steps in the PR checklist.
+
+## Commit & Pull Request Guidelines
+Write imperative, present-tense commit titles (`Add Drizzle migrations cache`, `feat(api): expose booking endpoint`) and wrap bodies near 72 characters. Reference issues in the footer when available. Pull requests should link to the business context, summarize scope, call out schema or env updates, attach UI screenshots when relevant, and list the checks you ran (`bun run lint`, `bun run build`). Tag the owners of each affected app.
+
+## Environment & Security Notes
+Develop with Node 18+ and Bun 1.2.x. Provide per-app `.env` files—`apps/api` needs `DRIZZLE_DATABASE_URL` or `DATABASE_URL` before migrations. Never commit secrets; update `.env.example` instead. For caching or deployment, authenticate Turbo (`bunx turbo login`) and platform CLIs with your own tokens.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # Repository Guidelines
 
 ## Project Overview (Hackathon MVP)
-Hairfluencer is an AI-powered hairstyle try-on mobile application built for a 14-day hackathon. Users upload selfies to instantly visualize new hairstyles via Nano Bana Image AI, with dual-language support (English/Spanish). The MVP targets 200+ sign-ups and 100+ try-ons in the first week.
+Hairfluencer is an AI-powered hairstyle try-on mobile application built for a 14-day hackathon. Users upload selfies to instantly visualize new hairstyles using FAL.ai's "nano-banana/edit" model, with dual-language support (English/Spanish). The MVP targets 200+ sign-ups and 100+ try-ons in the first week. Monetization is handled through Adapty for premium features and subscription management.
 
 ## Project Structure & Module Organization
 Hairfluencer is a Bun-driven Turborepo with three main applications:
@@ -42,12 +42,14 @@ Develop with Node 18+ and Bun 1.2.x. Each app requires specific environment vari
 - `BETTER_AUTH_SECRET` - Min 32 chars for session encryption
 - `BETTER_AUTH_URL` - API base URL for auth callbacks
 - `GOOGLE_CLIENT_ID` & `GOOGLE_CLIENT_SECRET` - Google OAuth credentials
-- `NANO_BANA_API_KEY` - AI service authentication (to be added)
+- `FAL_API_KEY` - FAL.ai authentication key for AI transformations
+- `FAL_MODEL_ID` - Set to "nano-banana/edit" for hairstyle editing
 - `FRONTEND_URL` - Mobile app URL for CORS
 
 ### Mobile Environment (`apps/mobile/.env`):
 - `EXPO_PUBLIC_API_URL` - Backend API URL
 - `EXPO_PUBLIC_GOOGLE_CLIENT_ID` - Google OAuth client ID for mobile
+- `EXPO_PUBLIC_ADAPTY_PUBLIC_KEY` - Adapty SDK public key for payments
 
 Never commit secrets; update `.env.example` instead. For deployment, use secure environment variable management.
 
@@ -62,7 +64,8 @@ Never commit secrets; update `.env.example` instead. For deployment, use secure 
 1. **Authentication**: Email/password + Google OAuth (✅ Completed)
 2. **Photo Upload**: Selfie validation with face detection (Pending)
 3. **Hairstyle Gallery**: Admin-managed style options with bilingual tags (Pending)
-4. **AI Transformation**: Nano Bana API integration for style application (Pending)
+4. **AI Transformation**: FAL.ai "nano-banana/edit" model integration (Pending)
 5. **Favorites System**: Save and manage favorite results (Pending)
 6. **Localization**: English/Spanish toggle throughout app (Pending)
 7. **Analytics**: Track funnel events and collect feedback (Pending)
+8. **Monetization**: Adapty paywall for premium features & subscriptions (Pending)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,14 +1,29 @@
 # Repository Guidelines
 
+## Project Overview (Hackathon MVP)
+Hairfluencer is an AI-powered hairstyle try-on mobile application built for a 14-day hackathon. Users upload selfies to instantly visualize new hairstyles via Nano Bana Image AI, with dual-language support (English/Spanish). The MVP targets 200+ sign-ups and 100+ try-ons in the first week.
+
 ## Project Structure & Module Organization
-Hairfluencer is a Bun-driven Turborepo. `apps/web` hosts the Next.js 15 site (`app/` routes, `public/` assets). `apps/mobile` contains the Expo Router client (`app/` screens, `components/` shared UI, `assets/` media). `apps/api` is a Bun + Hono service; route handlers sit in `src/`, database logic in `src/db`, and migrations in `src/db/migrations`. Shared lint and TypeScript presets live in `packages/eslint-config` and `packages/typescript-config`. Place reusable modules in `packages/` rather than duplicating inside apps.
+Hairfluencer is a Bun-driven Turborepo with three main applications:
+- `apps/mobile`: Expo Router client (PRIMARY) - User-facing mobile app for AI hairstyle try-ons (`app/` screens, `components/` shared UI, `assets/` media)
+- `apps/api`: Bun + Hono + Better Auth service - Backend API handling auth, photo uploads, AI orchestration (`src/` routes, `src/db` database, `src/db/migrations`)
+- `apps/web`: Next.js 15 admin panel - Gallery management and analytics dashboard (`app/` routes, `public/` assets)
+
+Shared configurations live in `packages/eslint-config` and `packages/typescript-config`. Place reusable modules in `packages/` rather than duplicating inside apps.
 
 ## Build, Test, and Development Commands
 - `bun install` (root) boots all workspaces.
-- `bun run dev` runs `turbo run dev`; limit scope with `bunx turbo run dev --filter=apps/web`, `apps/mobile`, or `apps/api`.
+- `bun run dev` runs all apps; limit scope with `bunx turbo run dev --filter=apps/api` for backend only.
 - `bun run build` executes every build pipeline and emits `.next/`, Expo, and API artifacts.
 - `bun run lint`, `bun run check-types`, and `bun run format` must succeed before a PR.
-- API migrations: `bunx drizzle-kit generate --config apps/api/drizzle.config.ts`, then commit the generated files.
+- **API specific**:
+  - `cd apps/api && bun run db:generate` - Generate Drizzle migrations
+  - `cd apps/api && bun run db:migrate` - Apply migrations to database
+  - `cd apps/api && bun run db:studio` - Open Drizzle Studio for database management
+- **Mobile specific**:
+  - `cd apps/mobile && bun ios` - Run on iOS simulator
+  - `cd apps/mobile && bun android` - Run on Android emulator
+  - `cd apps/mobile && bun start` - Start Expo development server
 
 ## Coding Style & Naming Conventions
 TypeScript is mandatory. Run `bun run format`; Prettier enforces two-space indentation and semicolons. Use PascalCase for React components/screens, camelCase for hooks and helpers, and UPPER_SNAKE_CASE for environment keys. Keep Tailwind class lists readable and colocate feature logic with the folder it supports. ESLint flat configs from `@repo/eslint-config` are required; if you disable a rule, leave a short reason. Resolve `turbo/no-undeclared-env-vars` warnings before merging.
@@ -20,4 +35,34 @@ A shared test runner is not configured yet. Add package-level scripts (`"test": 
 Write imperative, present-tense commit titles (`Add Drizzle migrations cache`, `feat(api): expose booking endpoint`) and wrap bodies near 72 characters. Reference issues in the footer when available. Pull requests should link to the business context, summarize scope, call out schema or env updates, attach UI screenshots when relevant, and list the checks you ran (`bun run lint`, `bun run build`). Tag the owners of each affected app.
 
 ## Environment & Security Notes
-Develop with Node 18+ and Bun 1.2.x. Provide per-app `.env` files—`apps/api` needs `DRIZZLE_DATABASE_URL` or `DATABASE_URL` before migrations. Never commit secrets; update `.env.example` instead. For caching or deployment, authenticate Turbo (`bunx turbo login`) and platform CLIs with your own tokens.
+Develop with Node 18+ and Bun 1.2.x. Each app requires specific environment variables:
+
+### API Environment (`apps/api/.env`):
+- `DATABASE_URL` - PostgreSQL connection string
+- `BETTER_AUTH_SECRET` - Min 32 chars for session encryption
+- `BETTER_AUTH_URL` - API base URL for auth callbacks
+- `GOOGLE_CLIENT_ID` & `GOOGLE_CLIENT_SECRET` - Google OAuth credentials
+- `NANO_BANA_API_KEY` - AI service authentication (to be added)
+- `FRONTEND_URL` - Mobile app URL for CORS
+
+### Mobile Environment (`apps/mobile/.env`):
+- `EXPO_PUBLIC_API_URL` - Backend API URL
+- `EXPO_PUBLIC_GOOGLE_CLIENT_ID` - Google OAuth client ID for mobile
+
+Never commit secrets; update `.env.example` instead. For deployment, use secure environment variable management.
+
+## PRD Success Metrics (Hackathon Goals)
+- **User Metrics**: 200+ sign-ups, 100+ completed try-ons in week 1
+- **Conversion**: 20%+ rate from first visit to try-on
+- **Feedback**: Minimum 50 survey responses
+- **Technical**: <8 second AI transformation (90th percentile), <5% error rate
+- **Availability**: 99% uptime during hackathon showcase
+
+## Key Features to Implement
+1. **Authentication**: Email/password + Google OAuth (✅ Completed)
+2. **Photo Upload**: Selfie validation with face detection (Pending)
+3. **Hairstyle Gallery**: Admin-managed style options with bilingual tags (Pending)
+4. **AI Transformation**: Nano Bana API integration for style application (Pending)
+5. **Favorites System**: Save and manage favorite results (Pending)
+6. **Localization**: English/Spanish toggle throughout app (Pending)
+7. **Analytics**: Track funnel events and collect feedback (Pending)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,8 @@ bun reset-project    # Reset to blank project template
 - **Database**: PostgreSQL with Drizzle ORM
 - **Admin Panel**: Next.js 15 with Turbopack, React 19, Tailwind CSS v4
 - **Authentication**: Better Auth with email/password and Google OAuth
-- **AI Integration**: Nano Bana Image AI (external API for hairstyle transformation)
+- **AI Integration**: FAL.ai platform using "nano-banana/edit" model for hairstyle transformation
+- **Payments & Monetization**: Adapty for paywall management and in-app purchases
 
 ### Database & Authentication
 - **Drizzle ORM** configuration in `apps/api/drizzle.config.ts`
@@ -83,9 +84,13 @@ FRONTEND_URL=http://localhost:3000
 GOOGLE_CLIENT_ID=your-google-client-id
 GOOGLE_CLIENT_SECRET=your-google-client-secret
 
-# AI Service (to be added)
-NANO_BANA_API_KEY=your-api-key
-NANO_BANA_API_URL=https://api.nanobana.ai
+# FAL.ai Integration (AI hairstyle transformation)
+FAL_API_KEY=your-fal-api-key
+FAL_MODEL_ID=nano-banana/edit
+
+# Adapty Integration (mobile payments)
+ADAPTY_PUBLIC_KEY=your-adapty-public-key
+ADAPTY_SECRET_KEY=your-adapty-secret-key
 ```
 
 ### Shared Packages

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,10 +4,13 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Hairfluencer is a Turborepo monorepo project with three main applications:
-- **Web**: Next.js 15 application with Turbopack
-- **API**: Bun-based Hono server with Drizzle ORM for database access
-- **Mobile**: Expo React Native application
+Hairfluencer is an AI-powered hairstyle try-on application built as a hackathon MVP. Users can upload selfies and instantly visualize new haircuts and colors using AI transformation, with support for English and Spanish languages.
+
+### Architecture
+- **Turborepo Monorepo**: Three main applications sharing configurations
+- **Mobile App**: Expo React Native app (primary client) - AI hairstyle visualization
+- **API Server**: Bun + Hono with Better Auth & Drizzle ORM - handles auth, photo uploads, AI orchestration
+- **Web Admin**: Next.js 15 with Turbopack - admin panel for managing hairstyle gallery
 
 ## Development Commands
 
@@ -45,21 +48,45 @@ bun lint             # Run Expo lint
 bun reset-project    # Reset to blank project template
 ```
 
-## Architecture
+## Tech Stack
 
-### Tech Stack
+### Core Technologies
 - **Package Manager**: Bun (v1.2.22)
 - **Monorepo Tool**: Turborepo with workspaces (apps/*, packages/*)
-- **Web Framework**: Next.js 15 with Turbopack, React 19, Tailwind CSS v4
-- **API Framework**: Hono on Bun runtime
-- **Database**: PostgreSQL with Drizzle ORM
 - **Mobile Framework**: Expo with React Native, expo-router for navigation
+- **API Framework**: Hono on Bun runtime with Better Auth
+- **Database**: PostgreSQL with Drizzle ORM
+- **Admin Panel**: Next.js 15 with Turbopack, React 19, Tailwind CSS v4
+- **Authentication**: Better Auth with email/password and Google OAuth
+- **AI Integration**: Nano Bana Image AI (external API for hairstyle transformation)
 
-### Database Setup
-- Drizzle ORM configuration in `apps/api/drizzle.config.ts`
+### Database & Authentication
+- **Drizzle ORM** configuration in `apps/api/drizzle.config.ts`
+- **Better Auth** configuration in `apps/api/src/auth.ts`
 - Schema definitions in `apps/api/src/db/schemas/`
 - Migrations stored in `apps/api/src/db/migrations/`
-- Requires `DATABASE_URL` or `DRIZZLE_DATABASE_URL` environment variable
+- Authentication tables: `user`, `session`, `account`, `verification`
+- Google OAuth support for mobile app login
+
+### Environment Variables Required
+```bash
+# Database
+DATABASE_URL=postgres://user:password@localhost:5432/hairfluencer
+DRIZZLE_DATABASE_URL=postgres://user:password@localhost:5432/hairfluencer
+
+# Authentication
+BETTER_AUTH_SECRET=minimum-32-character-secret-key
+BETTER_AUTH_URL=http://localhost:3000
+FRONTEND_URL=http://localhost:3000
+
+# Google OAuth (for mobile app)
+GOOGLE_CLIENT_ID=your-google-client-id
+GOOGLE_CLIENT_SECRET=your-google-client-secret
+
+# AI Service (to be added)
+NANO_BANA_API_KEY=your-api-key
+NANO_BANA_API_URL=https://api.nanobana.ai
+```
 
 ### Shared Packages
 - `packages/eslint-config`: Shared ESLint configurations
@@ -70,3 +97,27 @@ bun reset-project    # Reset to blank project template
 - Build outputs: `.next/**` for Next.js
 - Environment variables loaded from `.env*` files
 - Caching enabled for build and lint tasks
+
+## Key Features (PRD Requirements)
+
+### Core Functionality
+1. **AI Hairstyle Try-On**: Upload selfie → Select style → AI transformation
+2. **Dual Language Support**: English and Spanish UI localization
+3. **Authentication**: Email/password and Google OAuth (mobile optimized)
+4. **Favorites System**: Save and manage favorite hairstyle results
+5. **Admin Panel**: Manage hairstyle gallery and view usage statistics
+
+### API Endpoints
+- **Auth**: `/api/auth/*` (sign-up, sign-in, sign-out, google, session)
+- **Health**: `/api/health` - System health check
+- **Upload**: `/api/upload` (to be implemented) - Photo upload
+- **Styles**: `/api/styles` (to be implemented) - Hairstyle gallery
+- **Transform**: `/api/transform` (to be implemented) - AI processing
+- **Favorites**: `/api/favorites` (to be implemented) - User favorites
+
+### Mobile App Considerations
+- Session duration: 7 days (optimized for mobile usage)
+- Trusted origins configured for Expo development
+- Deep linking support: `hairfluencer://`
+- CORS configured for mobile app requests
+- Google OAuth redirect handling for mobile

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,72 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Hairfluencer is a Turborepo monorepo project with three main applications:
+- **Web**: Next.js 15 application with Turbopack
+- **API**: Bun-based Hono server with Drizzle ORM for database access
+- **Mobile**: Expo React Native application
+
+## Development Commands
+
+### Root-level commands (from project root):
+```bash
+bun dev              # Start all apps in development mode
+bun build            # Build all apps
+bun lint             # Run linting for all apps
+bun format           # Format all TypeScript and Markdown files
+bun check-types      # Type check all apps
+```
+
+### Web app (apps/web):
+```bash
+cd apps/web
+bun dev              # Start Next.js dev server with Turbopack (port 3000)
+bun build            # Build for production
+bun lint             # Run ESLint
+```
+
+### API app (apps/api):
+```bash
+cd apps/api
+bun dev              # Start Hono server with hot reload (port 3000)
+```
+
+### Mobile app (apps/mobile):
+```bash
+cd apps/mobile
+bun start            # Start Expo development server
+bun android          # Run on Android emulator/device
+bun ios              # Run on iOS simulator/device
+bun web              # Run in web browser
+bun lint             # Run Expo lint
+bun reset-project    # Reset to blank project template
+```
+
+## Architecture
+
+### Tech Stack
+- **Package Manager**: Bun (v1.2.22)
+- **Monorepo Tool**: Turborepo with workspaces (apps/*, packages/*)
+- **Web Framework**: Next.js 15 with Turbopack, React 19, Tailwind CSS v4
+- **API Framework**: Hono on Bun runtime
+- **Database**: PostgreSQL with Drizzle ORM
+- **Mobile Framework**: Expo with React Native, expo-router for navigation
+
+### Database Setup
+- Drizzle ORM configuration in `apps/api/drizzle.config.ts`
+- Schema definitions in `apps/api/src/db/schemas/`
+- Migrations stored in `apps/api/src/db/migrations/`
+- Requires `DATABASE_URL` or `DRIZZLE_DATABASE_URL` environment variable
+
+### Shared Packages
+- `packages/eslint-config`: Shared ESLint configurations
+- `packages/typescript-config`: Shared TypeScript configurations
+
+### Build Configuration
+- Turborepo pipeline defined in `turbo.json`
+- Build outputs: `.next/**` for Next.js
+- Environment variables loaded from `.env*` files
+- Caching enabled for build and lint tasks

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -4,5 +4,8 @@
 DATABASE_URL=postgres://user:password@localhost:5432/hairfluencer
 
 # Better Auth configuration
-BETTER_AUTH_SECRET=your-secret-here-change-in-production
+BETTER_AUTH_SECRET=your-secret-here-change-in-production-minimum-32-chars
 BETTER_AUTH_URL=http://localhost:3000
+
+# Frontend URL for CORS
+FRONTEND_URL=http://localhost:3000

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -2,10 +2,22 @@
 # For local development: postgres://user:password@localhost:5432/database
 # For production: Use your hosted PostgreSQL connection string
 DATABASE_URL=postgres://user:password@localhost:5432/hairfluencer
+DRIZZLE_DATABASE_URL=postgres://user:password@localhost:5432/hairfluencer
 
 # Better Auth configuration
+# Generate a secure secret: openssl rand -base64 32
 BETTER_AUTH_SECRET=your-secret-here-change-in-production-minimum-32-chars
 BETTER_AUTH_URL=http://localhost:3000
 
-# Frontend URL for CORS
+# Frontend URL for CORS (mobile app and web admin)
 FRONTEND_URL=http://localhost:3000
+
+# Google OAuth credentials (for mobile app login)
+# Get from: https://console.cloud.google.com/apis/credentials
+GOOGLE_CLIENT_ID=your-google-client-id.apps.googleusercontent.com
+GOOGLE_CLIENT_SECRET=your-google-client-secret
+
+# Nano Bana Image AI API (for hairstyle transformation)
+# Contact Nano Bana for API access
+NANO_BANA_API_KEY=your-nano-bana-api-key
+NANO_BANA_API_URL=https://api.nanobana.ai/v1

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -1,0 +1,8 @@
+# Database connection URL
+# For local development: postgres://user:password@localhost:5432/database
+# For production: Use your hosted PostgreSQL connection string
+DATABASE_URL=postgres://user:password@localhost:5432/hairfluencer
+
+# Better Auth configuration
+BETTER_AUTH_SECRET=your-secret-here-change-in-production
+BETTER_AUTH_URL=http://localhost:3000

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -17,7 +17,12 @@ FRONTEND_URL=http://localhost:3000
 GOOGLE_CLIENT_ID=your-google-client-id.apps.googleusercontent.com
 GOOGLE_CLIENT_SECRET=your-google-client-secret
 
-# Nano Bana Image AI API (for hairstyle transformation)
-# Contact Nano Bana for API access
-NANO_BANA_API_KEY=your-nano-bana-api-key
-NANO_BANA_API_URL=https://api.nanobana.ai/v1
+# FAL.ai Integration (AI hairstyle transformation)
+# Get API key from: https://fal.ai/dashboard/keys
+FAL_API_KEY=your-fal-api-key
+FAL_MODEL_ID=nano-banana/edit
+
+# Adapty Integration (payments and subscriptions)
+# Get keys from: https://app.adapty.io/settings/general
+ADAPTY_PUBLIC_KEY=public.adapty.your-public-key
+ADAPTY_SECRET_KEY=secret.adapty.your-secret-key

--- a/apps/api/API.md
+++ b/apps/api/API.md
@@ -1,12 +1,15 @@
 # API Documentation - Hairfluencer
 
+AI-powered hairstyle try-on application backend API for mobile and web clients.
+
 ## Base URL
 - Development: `http://localhost:3000`
 - Production: Configure via `BETTER_AUTH_URL` environment variable
+- Mobile Expo Dev: `exp://localhost:8081`
 
 ## Authentication Endpoints
 
-All authentication endpoints are prefixed with `/api/auth/`
+All authentication endpoints are prefixed with `/api/auth/`. The API supports both email/password and Google OAuth authentication optimized for mobile app usage.
 
 ### Register User
 **POST** `/api/auth/sign-up`
@@ -125,6 +128,35 @@ Headers: {
 }
 ```
 
+### Google OAuth Login
+**GET** `/api/auth/google`
+
+Initiate Google OAuth flow for mobile app login.
+
+```json
+// Request
+// Redirect user to this endpoint in mobile WebView or browser
+
+// Response
+// Redirects to Google OAuth consent page
+// After consent, redirects to: /api/auth/callback/google
+```
+
+### Google OAuth Callback
+**GET** `/api/auth/callback/google`
+
+Handle Google OAuth callback (automatically processed).
+
+```json
+// Response - Success
+// Redirects to mobile app with deep link:
+// hairfluencer://auth?token=<session-token>&user=<user-data>
+
+// Response - Error
+// Redirects to mobile app with error:
+// hairfluencer://auth?error=<error-message>
+```
+
 ## Health Check Endpoint
 
 ### System Health
@@ -158,9 +190,14 @@ Required environment variables for the API:
 | Variable | Description | Example |
 |----------|-------------|---------|
 | `DATABASE_URL` | PostgreSQL connection string | `postgres://user:pass@localhost:5432/hairfluencer` |
+| `DRIZZLE_DATABASE_URL` | Alternative DB URL for migrations | `postgres://user:pass@localhost:5432/hairfluencer` |
 | `BETTER_AUTH_SECRET` | Secret key for auth (min 32 chars) | `your-super-secret-key-minimum-32-characters` |
 | `BETTER_AUTH_URL` | Base URL for auth callbacks | `http://localhost:3000` |
 | `FRONTEND_URL` | Frontend URL for CORS | `http://localhost:3000` |
+| `GOOGLE_CLIENT_ID` | Google OAuth client ID | `123456.apps.googleusercontent.com` |
+| `GOOGLE_CLIENT_SECRET` | Google OAuth client secret | `GOCSPX-xxxxxxxxxxxxx` |
+| `NANO_BANA_API_KEY` | AI service API key (pending) | `your-api-key` |
+| `NANO_BANA_API_URL` | AI service endpoint (pending) | `https://api.nanobana.ai/v1` |
 
 ## Error Handling
 
@@ -184,15 +221,23 @@ Common HTTP status codes:
 - `500` - Internal Server Error
 - `503` - Service Unavailable (database issues)
 
-## CORS Configuration
+## CORS & Mobile App Configuration
 
-The API is configured to accept requests from the frontend URL specified in the `FRONTEND_URL` environment variable.
+The API is configured to accept requests from mobile apps and web clients.
 
-Default CORS settings:
-- Origin: `FRONTEND_URL` or `http://localhost:3000`
+### CORS Settings:
+- Origins:
+  - `FRONTEND_URL` (web admin)
+  - `exp://localhost:8081` (Expo development)
+  - `hairfluencer://` (mobile app deep links)
 - Credentials: Enabled
 - Allowed Methods: `GET`, `POST`, `PUT`, `DELETE`, `OPTIONS`
 - Allowed Headers: `Content-Type`, `Authorization`
+
+### Mobile-Specific Settings:
+- Session duration: 7 days (optimized for mobile usage)
+- Deep link support for OAuth callbacks
+- Token-based authentication for API calls
 
 ## Rate Limiting
 

--- a/apps/api/API.md
+++ b/apps/api/API.md
@@ -196,8 +196,10 @@ Required environment variables for the API:
 | `FRONTEND_URL` | Frontend URL for CORS | `http://localhost:3000` |
 | `GOOGLE_CLIENT_ID` | Google OAuth client ID | `123456.apps.googleusercontent.com` |
 | `GOOGLE_CLIENT_SECRET` | Google OAuth client secret | `GOCSPX-xxxxxxxxxxxxx` |
-| `NANO_BANA_API_KEY` | AI service API key (pending) | `your-api-key` |
-| `NANO_BANA_API_URL` | AI service endpoint (pending) | `https://api.nanobana.ai/v1` |
+| `FAL_API_KEY` | FAL.ai API key for AI transformations | `your-fal-api-key` |
+| `FAL_MODEL_ID` | FAL.ai model identifier | `nano-banana/edit` |
+| `ADAPTY_PUBLIC_KEY` | Adapty public SDK key | `public.adapty.xxxxx` |
+| `ADAPTY_SECRET_KEY` | Adapty server-side secret key | `secret.adapty.xxxxx` |
 
 ## Error Handling
 
@@ -274,6 +276,22 @@ Run migrations with:
 cd apps/api
 bun run db:migrate
 ```
+
+## Third-Party Integrations
+
+### FAL.ai Integration
+The API uses FAL.ai's "nano-banana/edit" model for AI-powered hairstyle transformations:
+- Model: `nano-banana/edit`
+- Documentation: https://fal.ai/models/nano-banana/edit
+- Features: Image editing with style transfer for hairstyle modifications
+- Response time: Target <8 seconds for 90th percentile
+
+### Adapty Integration
+Payment processing and subscription management through Adapty:
+- SDK: Mobile SDK for iOS/Android
+- Features: Paywall management, subscription handling, analytics
+- Documentation: https://docs.adapty.io/
+- Webhook endpoint: `/api/webhooks/adapty` (to be implemented)
 
 ## Development
 

--- a/apps/api/API.md
+++ b/apps/api/API.md
@@ -1,0 +1,241 @@
+# API Documentation - Hairfluencer
+
+## Base URL
+- Development: `http://localhost:3000`
+- Production: Configure via `BETTER_AUTH_URL` environment variable
+
+## Authentication Endpoints
+
+All authentication endpoints are prefixed with `/api/auth/`
+
+### Register User
+**POST** `/api/auth/sign-up`
+
+Create a new user account with email and password.
+
+```json
+// Request
+{
+  "email": "user@example.com",
+  "password": "securePassword123",
+  "name": "John Doe" // Optional
+}
+
+// Response - Success (201)
+{
+  "user": {
+    "id": "uuid",
+    "email": "user@example.com",
+    "name": "John Doe",
+    "emailVerified": false,
+    "createdAt": "2025-09-21T10:00:00Z"
+  },
+  "session": {
+    "id": "session-uuid",
+    "userId": "user-uuid",
+    "token": "session-token",
+    "expiresAt": "2025-09-28T10:00:00Z"
+  }
+}
+
+// Response - Error (400)
+{
+  "error": "Email already exists"
+}
+```
+
+### Login
+**POST** `/api/auth/sign-in`
+
+Authenticate user with email and password.
+
+```json
+// Request
+{
+  "email": "user@example.com",
+  "password": "securePassword123"
+}
+
+// Response - Success (200)
+{
+  "user": {
+    "id": "uuid",
+    "email": "user@example.com",
+    "name": "John Doe",
+    "emailVerified": true
+  },
+  "session": {
+    "id": "session-uuid",
+    "token": "session-token",
+    "expiresAt": "2025-09-28T10:00:00Z"
+  }
+}
+
+// Response - Error (401)
+{
+  "error": "Invalid credentials"
+}
+```
+
+### Logout
+**POST** `/api/auth/sign-out`
+
+End current user session.
+
+```json
+// Request
+Headers: {
+  "Authorization": "Bearer <session-token>"
+}
+
+// Response - Success (200)
+{
+  "success": true
+}
+```
+
+### Get Session
+**GET** `/api/auth/session`
+
+Get current user session information.
+
+```json
+// Request
+Headers: {
+  "Authorization": "Bearer <session-token>"
+}
+
+// Response - Success (200)
+{
+  "user": {
+    "id": "uuid",
+    "email": "user@example.com",
+    "name": "John Doe",
+    "emailVerified": true
+  },
+  "session": {
+    "id": "session-uuid",
+    "expiresAt": "2025-09-28T10:00:00Z"
+  }
+}
+
+// Response - Error (401)
+{
+  "error": "Not authenticated"
+}
+```
+
+## Health Check Endpoint
+
+### System Health
+**GET** `/api/health`
+
+Check API and database connectivity status.
+
+```json
+// Response - Success (200)
+{
+  "status": "healthy",
+  "services": {
+    "database": "connected",
+    "auth": "operational"
+  },
+  "timestamp": "2025-09-21T10:00:00.000Z"
+}
+
+// Response - Error (503)
+{
+  "status": "unhealthy",
+  "error": "Database connection failed",
+  "timestamp": "2025-09-21T10:00:00.000Z"
+}
+```
+
+## Environment Variables
+
+Required environment variables for the API:
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `DATABASE_URL` | PostgreSQL connection string | `postgres://user:pass@localhost:5432/hairfluencer` |
+| `BETTER_AUTH_SECRET` | Secret key for auth (min 32 chars) | `your-super-secret-key-minimum-32-characters` |
+| `BETTER_AUTH_URL` | Base URL for auth callbacks | `http://localhost:3000` |
+| `FRONTEND_URL` | Frontend URL for CORS | `http://localhost:3000` |
+
+## Error Handling
+
+All endpoints follow consistent error response format:
+
+```json
+{
+  "error": "Error message description",
+  "code": "ERROR_CODE", // Optional error code
+  "details": {} // Optional additional details
+}
+```
+
+Common HTTP status codes:
+- `200` - Success
+- `201` - Created
+- `400` - Bad Request (validation errors)
+- `401` - Unauthorized (authentication required)
+- `403` - Forbidden (insufficient permissions)
+- `404` - Not Found
+- `500` - Internal Server Error
+- `503` - Service Unavailable (database issues)
+
+## CORS Configuration
+
+The API is configured to accept requests from the frontend URL specified in the `FRONTEND_URL` environment variable.
+
+Default CORS settings:
+- Origin: `FRONTEND_URL` or `http://localhost:3000`
+- Credentials: Enabled
+- Allowed Methods: `GET`, `POST`, `PUT`, `DELETE`, `OPTIONS`
+- Allowed Headers: `Content-Type`, `Authorization`
+
+## Rate Limiting
+
+Currently not implemented. Consider adding rate limiting for production:
+- Sign-up: 5 requests per hour per IP
+- Sign-in: 10 requests per 15 minutes per IP
+- API calls: 100 requests per minute per user
+
+## Security Notes
+
+1. **Password Requirements**:
+   - Minimum length: 8 characters
+   - Maximum length: 128 characters
+
+2. **Session Management**:
+   - Sessions expire after 7 days
+   - Sessions are updated every 24 hours of activity
+
+3. **Database Security**:
+   - Connection pooling with max 10 clients
+   - 30-second idle timeout
+   - 10-second connection timeout
+
+## Database Schema
+
+The API uses the following tables:
+- `user` - User accounts
+- `session` - Active user sessions
+- `account` - OAuth and password accounts
+- `verification` - Email verification tokens
+
+Run migrations with:
+```bash
+cd apps/api
+bun run db:migrate
+```
+
+## Development
+
+Start the development server:
+```bash
+cd apps/api
+bun dev
+```
+
+The server will start on port 3000 with hot reload enabled.

--- a/apps/api/drizzle.config.ts
+++ b/apps/api/drizzle.config.ts
@@ -1,0 +1,21 @@
+import 'dotenv/config';
+import { defineConfig } from 'drizzle-kit';
+
+// For migrations and introspection, prefer a direct Postgres URL.
+// Use DRIZZLE_DATABASE_URL if set; otherwise fall back to DATABASE_URL.
+// Avoid PgBouncer for DDL-heavy operations where possible.
+const MIGRATIONS_DB_URL =
+  process.env.DRIZZLE_DATABASE_URL || process.env.DATABASE_URL;
+
+if (!MIGRATIONS_DB_URL) {
+  throw new Error('DRIZZLE_DATABASE_URL or DATABASE_URL must be set for drizzle-kit');
+}
+
+export default defineConfig({
+  out: './src/db/migrations',
+  schema: './src/db/schemas/index.ts',
+  dialect: 'postgresql',
+  dbCredentials: {
+    url: MIGRATIONS_DB_URL,
+  },
+});

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -4,6 +4,7 @@
     "dev": "bun run --hot src/index.ts"
   },
   "dependencies": {
+    "better-auth": "^1.3.13",
     "dotenv": "^17.2.2",
     "drizzle-orm": "^0.44.5",
     "hono": "^4.9.8",

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,7 +1,12 @@
 {
   "name": "api",
   "scripts": {
-    "dev": "bun run --hot src/index.ts"
+    "dev": "bun run --hot src/index.ts",
+    "db:generate": "bunx drizzle-kit generate",
+    "db:migrate": "bunx drizzle-kit migrate",
+    "db:push": "bunx drizzle-kit push",
+    "db:studio": "bunx drizzle-kit studio",
+    "db:seed": "bun run src/db/seed.ts"
   },
   "dependencies": {
     "better-auth": "^1.3.13",

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -4,9 +4,15 @@
     "dev": "bun run --hot src/index.ts"
   },
   "dependencies": {
-    "hono": "^4.9.8"
+    "dotenv": "^17.2.2",
+    "drizzle-orm": "^0.44.5",
+    "hono": "^4.9.8",
+    "pg": "^8.16.3"
   },
   "devDependencies": {
-    "@types/bun": "latest"
+    "@types/bun": "latest",
+    "@types/pg": "^8.15.5",
+    "drizzle-kit": "^0.31.4",
+    "tsx": "^4.20.5"
   }
 }

--- a/apps/api/src/auth-types.ts
+++ b/apps/api/src/auth-types.ts
@@ -1,0 +1,34 @@
+import { auth } from './auth';
+import type { Session, User } from 'better-auth';
+
+// Export Better Auth types for frontend usage
+export type AuthSession = Session;
+export type AuthUser = User;
+export type AuthClient = typeof auth.client;
+
+// Configuration for frontend client initialization
+export const authClientConfig = {
+  baseURL: process.env.BETTER_AUTH_URL || 'http://localhost:3000',
+  credentials: 'include' as RequestCredentials,
+};
+
+// Helper type for API responses
+export interface AuthResponse<T = any> {
+  success: boolean;
+  data?: T;
+  error?: string;
+}
+
+// User registration/login types
+export interface AuthCredentials {
+  email: string;
+  password: string;
+  name?: string;
+}
+
+// Session info for frontend
+export interface SessionInfo {
+  user: AuthUser | null;
+  session: AuthSession | null;
+  isAuthenticated: boolean;
+}

--- a/apps/api/src/auth.ts
+++ b/apps/api/src/auth.ts
@@ -2,12 +2,36 @@ import { betterAuth } from "better-auth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { db } from "./db";
 
+// Validate required environment variables
+const requiredEnvVars = {
+  BETTER_AUTH_SECRET: process.env.BETTER_AUTH_SECRET,
+  BETTER_AUTH_URL: process.env.BETTER_AUTH_URL,
+  DATABASE_URL: process.env.DATABASE_URL
+};
+
+for (const [key, value] of Object.entries(requiredEnvVars)) {
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${key}`);
+  }
+}
+
+// Validate secret strength
+if (process.env.BETTER_AUTH_SECRET && process.env.BETTER_AUTH_SECRET.length < 32) {
+  console.warn('WARNING: BETTER_AUTH_SECRET should be at least 32 characters for production');
+}
+
 export const auth = betterAuth({
   database: drizzleAdapter(db, {
     provider: "pg", // PostgreSQL provider
   }),
   emailAndPassword: {
     enabled: true,
+    minPasswordLength: 8,
+    maxPasswordLength: 128,
+  },
+  session: {
+    expiresIn: 60 * 60 * 24 * 7,  // 7 days
+    updateAge: 60 * 60 * 24,       // Update session every 24 hours
   },
   socialProviders: {
     // Add social providers later if needed

--- a/apps/api/src/auth.ts
+++ b/apps/api/src/auth.ts
@@ -1,0 +1,15 @@
+import { betterAuth } from "better-auth";
+import { drizzleAdapter } from "better-auth/adapters/drizzle";
+import { db } from "./db";
+
+export const auth = betterAuth({
+  database: drizzleAdapter(db, {
+    provider: "pg", // PostgreSQL provider
+  }),
+  emailAndPassword: {
+    enabled: true,
+  },
+  socialProviders: {
+    // Add social providers later if needed
+  },
+});

--- a/apps/api/src/db/index.ts
+++ b/apps/api/src/db/index.ts
@@ -2,8 +2,33 @@ import { drizzle } from 'drizzle-orm/node-postgres';
 import { Pool } from 'pg';
 import * as schema from './schemas';
 
+// Validate database URL exists
+if (!process.env.DATABASE_URL) {
+  throw new Error('DATABASE_URL environment variable is required');
+}
+
 const pool = new Pool({
   connectionString: process.env.DATABASE_URL,
+  max: 10, // Maximum number of clients in the pool
+  idleTimeoutMillis: 30000, // Close idle clients after 30 seconds
+  connectionTimeoutMillis: 10000, // Timeout connection after 10 seconds
+});
+
+// Add connection error handling
+pool.on('error', (err) => {
+  console.error('Unexpected database pool error:', err.message);
+  // Don't log the full error object which might contain connection string
+});
+
+pool.on('connect', () => {
+  console.log('Database pool: New client connected');
+});
+
+pool.on('remove', () => {
+  console.log('Database pool: Client removed');
 });
 
 export const db = drizzle(pool, { schema });
+
+// Export pool for health checks
+export { pool };

--- a/apps/api/src/db/index.ts
+++ b/apps/api/src/db/index.ts
@@ -1,0 +1,9 @@
+import { drizzle } from 'drizzle-orm/node-postgres';
+import { Pool } from 'pg';
+import * as schema from './schemas';
+
+const pool = new Pool({
+  connectionString: process.env.DATABASE_URL,
+});
+
+export const db = drizzle(pool, { schema });

--- a/apps/api/src/db/schemas/auth-schema.ts
+++ b/apps/api/src/db/schemas/auth-schema.ts
@@ -1,0 +1,61 @@
+import { pgTable, text, timestamp, boolean } from "drizzle-orm/pg-core";
+
+export const user = pgTable("user", {
+  id: text("id").primaryKey(),
+  name: text("name").notNull(),
+  email: text("email").notNull().unique(),
+  emailVerified: boolean("email_verified").default(false).notNull(),
+  image: text("image"),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+  updatedAt: timestamp("updated_at")
+    .defaultNow()
+    .$onUpdate(() => /* @__PURE__ */ new Date())
+    .notNull(),
+});
+
+export const session = pgTable("session", {
+  id: text("id").primaryKey(),
+  expiresAt: timestamp("expires_at").notNull(),
+  token: text("token").notNull().unique(),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+  updatedAt: timestamp("updated_at")
+    .$onUpdate(() => /* @__PURE__ */ new Date())
+    .notNull(),
+  ipAddress: text("ip_address"),
+  userAgent: text("user_agent"),
+  userId: text("user_id")
+    .notNull()
+    .references(() => user.id, { onDelete: "cascade" }),
+});
+
+export const account = pgTable("account", {
+  id: text("id").primaryKey(),
+  accountId: text("account_id").notNull(),
+  providerId: text("provider_id").notNull(),
+  userId: text("user_id")
+    .notNull()
+    .references(() => user.id, { onDelete: "cascade" }),
+  accessToken: text("access_token"),
+  refreshToken: text("refresh_token"),
+  idToken: text("id_token"),
+  accessTokenExpiresAt: timestamp("access_token_expires_at"),
+  refreshTokenExpiresAt: timestamp("refresh_token_expires_at"),
+  scope: text("scope"),
+  password: text("password"),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+  updatedAt: timestamp("updated_at")
+    .$onUpdate(() => /* @__PURE__ */ new Date())
+    .notNull(),
+});
+
+export const verification = pgTable("verification", {
+  id: text("id").primaryKey(),
+  identifier: text("identifier").notNull(),
+  value: text("value").notNull(),
+  expiresAt: timestamp("expires_at").notNull(),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+  updatedAt: timestamp("updated_at")
+    .defaultNow()
+    .$onUpdate(() => /* @__PURE__ */ new Date())
+    .notNull(),
+});

--- a/apps/api/src/db/schemas/index.ts
+++ b/apps/api/src/db/schemas/index.ts
@@ -1,0 +1,1 @@
+export * from './auth-schema';

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,9 +1,15 @@
 import { Hono } from 'hono'
+import { auth } from './auth'
 
 const app = new Hono()
 
 app.get('/', (c) => {
   return c.text('Hello Hono!')
+})
+
+// Mount Better Auth routes
+app.on(['POST', 'GET'], '/api/auth/*', (c) => {
+  return auth.handler(c.req.raw)
 })
 
 export default app

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,7 +1,43 @@
 import { Hono } from 'hono'
+import { cors } from 'hono/cors'
 import { auth } from './auth'
+import { db, pool } from './db'
+import * as schema from './db/schemas'
 
 const app = new Hono()
+
+// Configure CORS for auth routes
+app.use('/api/auth/*', cors({
+  origin: process.env.FRONTEND_URL || 'http://localhost:3000',
+  credentials: true,
+  allowMethods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
+  allowHeaders: ['Content-Type', 'Authorization'],
+}))
+
+// Health check endpoint
+app.get('/api/health', async (c) => {
+  try {
+    // Check database connection
+    const client = await pool.connect();
+    await client.query('SELECT 1');
+    client.release();
+
+    return c.json({
+      status: 'healthy',
+      services: {
+        database: 'connected',
+        auth: 'operational',
+      },
+      timestamp: new Date().toISOString(),
+    });
+  } catch (error) {
+    return c.json({
+      status: 'unhealthy',
+      error: 'Database connection failed',
+      timestamp: new Date().toISOString(),
+    }, 503);
+  }
+});
 
 app.get('/', (c) => {
   return c.text('Hello Hono!')

--- a/bun.lock
+++ b/bun.lock
@@ -3,6 +3,9 @@
   "workspaces": {
     "": {
       "name": "hairfluencer",
+      "dependencies": {
+        "hono": "^4.9.8",
+      },
       "devDependencies": {
         "prettier": "^3.6.2",
         "turbo": "^2.5.6",

--- a/bun.lock
+++ b/bun.lock
@@ -12,10 +12,16 @@
     "apps/api": {
       "name": "api",
       "dependencies": {
+        "dotenv": "^17.2.2",
+        "drizzle-orm": "^0.44.5",
         "hono": "^4.9.8",
+        "pg": "^8.16.3",
       },
       "devDependencies": {
         "@types/bun": "latest",
+        "@types/pg": "^8.15.5",
+        "drizzle-kit": "^0.31.4",
+        "tsx": "^4.20.5",
       },
     },
     "apps/mobile": {
@@ -290,6 +296,8 @@
 
     "@babel/types": ["@babel/types@7.28.4", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.27.1" } }, "sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q=="],
 
+    "@drizzle-team/brocli": ["@drizzle-team/brocli@0.10.2", "", {}, "sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w=="],
+
     "@egjs/hammerjs": ["@egjs/hammerjs@2.0.17", "", { "dependencies": { "@types/hammerjs": "^2.0.36" } }, "sha512-XQsZgjm2EcVUiZQf11UBJQfmZeEmOW8DpI1gsFeln6w0ae0ii4dMQEQ0kjl6DspdWX1aGY1/loyXnP0JS06e/A=="],
 
     "@emnapi/core": ["@emnapi/core@1.5.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.1.0", "tslib": "^2.4.0" } }, "sha512-sbP8GzB1WDzacS8fgNPpHlp6C9VZe+SJP3F90W9rLemaQj2PzIuTEl1qDOYQf58YIpyjViI24y9aPWCjEzY2cg=="],
@@ -297,6 +305,62 @@
     "@emnapi/runtime": ["@emnapi/runtime@1.5.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-97/BJ3iXHww3djw6hYIfErCZFee7qCtrneuLa20UXFCOTCfBM2cvQHjWJ2EG0s0MtdNwInarqCTz35i4wWXHsQ=="],
 
     "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.1.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ=="],
+
+    "@esbuild-kit/core-utils": ["@esbuild-kit/core-utils@3.3.2", "", { "dependencies": { "esbuild": "~0.18.20", "source-map-support": "^0.5.21" } }, "sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ=="],
+
+    "@esbuild-kit/esm-loader": ["@esbuild-kit/esm-loader@2.6.5", "", { "dependencies": { "@esbuild-kit/core-utils": "^3.3.2", "get-tsconfig": "^4.7.0" } }, "sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA=="],
+
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.10", "", { "os": "aix", "cpu": "ppc64" }, "sha512-0NFWnA+7l41irNuaSVlLfgNT12caWJVLzp5eAVhZ0z1qpxbockccEt3s+149rE64VUI3Ml2zt8Nv5JVc4QXTsw=="],
+
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.25.10", "", { "os": "android", "cpu": "arm" }, "sha512-dQAxF1dW1C3zpeCDc5KqIYuZ1tgAdRXNoZP7vkBIRtKZPYe2xVr/d3SkirklCHudW1B45tGiUlz2pUWDfbDD4w=="],
+
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.25.10", "", { "os": "android", "cpu": "arm64" }, "sha512-LSQa7eDahypv/VO6WKohZGPSJDq5OVOo3UoFR1E4t4Gj1W7zEQMUhI+lo81H+DtB+kP+tDgBp+M4oNCwp6kffg=="],
+
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.25.10", "", { "os": "android", "cpu": "x64" }, "sha512-MiC9CWdPrfhibcXwr39p9ha1x0lZJ9KaVfvzA0Wxwz9ETX4v5CHfF09bx935nHlhi+MxhA63dKRRQLiVgSUtEg=="],
+
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.25.10", "", { "os": "darwin", "cpu": "arm64" }, "sha512-JC74bdXcQEpW9KkV326WpZZjLguSZ3DfS8wrrvPMHgQOIEIG/sPXEN/V8IssoJhbefLRcRqw6RQH2NnpdprtMA=="],
+
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.25.10", "", { "os": "darwin", "cpu": "x64" }, "sha512-tguWg1olF6DGqzws97pKZ8G2L7Ig1vjDmGTwcTuYHbuU6TTjJe5FXbgs5C1BBzHbJ2bo1m3WkQDbWO2PvamRcg=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.25.10", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-3ZioSQSg1HT2N05YxeJWYR+Libe3bREVSdWhEEgExWaDtyFbbXWb49QgPvFH8u03vUPX10JhJPcz7s9t9+boWg=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.25.10", "", { "os": "freebsd", "cpu": "x64" }, "sha512-LLgJfHJk014Aa4anGDbh8bmI5Lk+QidDmGzuC2D+vP7mv/GeSN+H39zOf7pN5N8p059FcOfs2bVlrRr4SK9WxA=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.25.10", "", { "os": "linux", "cpu": "arm" }, "sha512-oR31GtBTFYCqEBALI9r6WxoU/ZofZl962pouZRTEYECvNF/dtXKku8YXcJkhgK/beU+zedXfIzHijSRapJY3vg=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.25.10", "", { "os": "linux", "cpu": "arm64" }, "sha512-5luJWN6YKBsawd5f9i4+c+geYiVEw20FVW5x0v1kEMWNq8UctFjDiMATBxLvmmHA4bf7F6hTRaJgtghFr9iziQ=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.25.10", "", { "os": "linux", "cpu": "ia32" }, "sha512-NrSCx2Kim3EnnWgS4Txn0QGt0Xipoumb6z6sUtl5bOEZIVKhzfyp/Lyw4C1DIYvzeW/5mWYPBFJU3a/8Yr75DQ=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.25.10", "", { "os": "linux", "cpu": "none" }, "sha512-xoSphrd4AZda8+rUDDfD9J6FUMjrkTz8itpTITM4/xgerAZZcFW7Dv+sun7333IfKxGG8gAq+3NbfEMJfiY+Eg=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.25.10", "", { "os": "linux", "cpu": "none" }, "sha512-ab6eiuCwoMmYDyTnyptoKkVS3k8fy/1Uvq7Dj5czXI6DF2GqD2ToInBI0SHOp5/X1BdZ26RKc5+qjQNGRBelRA=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.25.10", "", { "os": "linux", "cpu": "ppc64" }, "sha512-NLinzzOgZQsGpsTkEbdJTCanwA5/wozN9dSgEl12haXJBzMTpssebuXR42bthOF3z7zXFWH1AmvWunUCkBE4EA=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.25.10", "", { "os": "linux", "cpu": "none" }, "sha512-FE557XdZDrtX8NMIeA8LBJX3dC2M8VGXwfrQWU7LB5SLOajfJIxmSdyL/gU1m64Zs9CBKvm4UAuBp5aJ8OgnrA=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.25.10", "", { "os": "linux", "cpu": "s390x" }, "sha512-3BBSbgzuB9ajLoVZk0mGu+EHlBwkusRmeNYdqmznmMc9zGASFjSsxgkNsqmXugpPk00gJ0JNKh/97nxmjctdew=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.25.10", "", { "os": "linux", "cpu": "x64" }, "sha512-QSX81KhFoZGwenVyPoberggdW1nrQZSvfVDAIUXr3WqLRZGZqWk/P4T8p2SP+de2Sr5HPcvjhcJzEiulKgnxtA=="],
+
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.25.10", "", { "os": "none", "cpu": "arm64" }, "sha512-AKQM3gfYfSW8XRk8DdMCzaLUFB15dTrZfnX8WXQoOUpUBQ+NaAFCP1kPS/ykbbGYz7rxn0WS48/81l9hFl3u4A=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.25.10", "", { "os": "none", "cpu": "x64" }, "sha512-7RTytDPGU6fek/hWuN9qQpeGPBZFfB4zZgcz2VK2Z5VpdUxEI8JKYsg3JfO0n/Z1E/6l05n0unDCNc4HnhQGig=="],
+
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.25.10", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-5Se0VM9Wtq797YFn+dLimf2Zx6McttsH2olUBsDml+lm0GOCRVebRWUvDtkY4BWYv/3NgzS8b/UM3jQNh5hYyw=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.25.10", "", { "os": "openbsd", "cpu": "x64" }, "sha512-XkA4frq1TLj4bEMB+2HnI0+4RnjbuGZfet2gs/LNs5Hc7D89ZQBHQ0gL2ND6Lzu1+QVkjp3x1gIcPKzRNP8bXw=="],
+
+    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.25.10", "", { "os": "none", "cpu": "arm64" }, "sha512-AVTSBhTX8Y/Fz6OmIVBip9tJzZEUcY8WLh7I59+upa5/GPhh2/aM6bvOMQySspnCCHvFi79kMtdJS1w0DXAeag=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.25.10", "", { "os": "sunos", "cpu": "x64" }, "sha512-fswk3XT0Uf2pGJmOpDB7yknqhVkJQkAQOcW/ccVOtfx05LkbWOaRAtn5SaqXypeKQra1QaEa841PgrSL9ubSPQ=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.25.10", "", { "os": "win32", "cpu": "arm64" }, "sha512-ah+9b59KDTSfpaCg6VdJoOQvKjI33nTaQr4UluQwW7aEwZQsbMCfTmfEO4VyewOxx4RaDT/xCy9ra2GPWmO7Kw=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.25.10", "", { "os": "win32", "cpu": "ia32" }, "sha512-QHPDbKkrGO8/cz9LKVnJU22HOi4pxZnZhhA2HYHez5Pz4JeffhDjf85E57Oyco163GnzNCVkZK0b/n4Y0UHcSw=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.10", "", { "os": "win32", "cpu": "x64" }, "sha512-9KpxSVFCu0iK1owoez6aC/s/EdUQLDN3adTxGCqxMVhrPDj6bt5dbrHDXUuq+Bs2vATFBBrQS5vdQ/Ed2P+nbw=="],
 
     "@eslint-community/eslint-utils": ["@eslint-community/eslint-utils@4.9.0", "", { "dependencies": { "eslint-visitor-keys": "^3.4.3" }, "peerDependencies": { "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0" } }, "sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g=="],
 
@@ -642,6 +706,8 @@
 
     "@types/node": ["@types/node@20.19.17", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-gfehUI8N1z92kygssiuWvLiwcbOB3IRktR6hTDgJlXMYh5OvkPSRmgfoBUmfZt+vhwJtX7v1Yw4KvvAf7c5QKQ=="],
 
+    "@types/pg": ["@types/pg@8.15.5", "", { "dependencies": { "@types/node": "*", "pg-protocol": "*", "pg-types": "^2.2.0" } }, "sha512-LF7lF6zWEKxuT3/OR8wAZGzkg4ENGXFNyiV/JeOt9z5B+0ZVwbql9McqX5c/WStFq1GaGso7H1AzP/qSzmlCKQ=="],
+
     "@types/react": ["@types/react@19.1.0", "", { "dependencies": { "csstype": "^3.0.2" } }, "sha512-UaicktuQI+9UKyA4njtDOGBD/67t8YEBt2xdfqu8+gP9hqPUPsiXlNPcpS2gVdjmis5GKPG3fCxbQLVgxsQZ8w=="],
 
     "@types/react-dom": ["@types/react-dom@19.1.1", "", { "peerDependencies": { "@types/react": "^19.0.0" } }, "sha512-jFf/woGTVTjUJsl2O7hcopJ1r0upqoq/vIOoCj0yLh3RIXxWcljlpuZ+vEBRXsymD1jhfeJrlyTy/S1UW+4y1w=="],
@@ -944,9 +1010,13 @@
 
     "doctrine": ["doctrine@2.1.0", "", { "dependencies": { "esutils": "^2.0.2" } }, "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw=="],
 
-    "dotenv": ["dotenv@16.0.3", "", {}, "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ=="],
+    "dotenv": ["dotenv@17.2.2", "", {}, "sha512-Sf2LSQP+bOlhKWWyhFsn0UsfdK/kCWRv1iuA2gXAwt3dyNabr6QSj00I2V10pidqz69soatm9ZwZvpQMTIOd5Q=="],
 
     "dotenv-expand": ["dotenv-expand@11.0.7", "", { "dependencies": { "dotenv": "^16.4.5" } }, "sha512-zIHwmZPRshsCdpMDyVsqGmgyP0yT8GAgXUnkdAoJisxvf33k7yO6OuoKmcTGuXPWSsm8Oh88nZicRLA9Y0rUeA=="],
+
+    "drizzle-kit": ["drizzle-kit@0.31.4", "", { "dependencies": { "@drizzle-team/brocli": "^0.10.2", "@esbuild-kit/esm-loader": "^2.5.5", "esbuild": "^0.25.4", "esbuild-register": "^3.5.0" }, "bin": { "drizzle-kit": "bin.cjs" } }, "sha512-tCPWVZWZqWVx2XUsVpJRnH9Mx0ClVOf5YUHerZ5so1OKSlqww4zy1R5ksEdGRcO3tM3zj0PYN6V48TbQCL1RfA=="],
+
+    "drizzle-orm": ["drizzle-orm@0.44.5", "", { "peerDependencies": { "@aws-sdk/client-rds-data": ">=3", "@cloudflare/workers-types": ">=4", "@electric-sql/pglite": ">=0.2.0", "@libsql/client": ">=0.10.0", "@libsql/client-wasm": ">=0.10.0", "@neondatabase/serverless": ">=0.10.0", "@op-engineering/op-sqlite": ">=2", "@opentelemetry/api": "^1.4.1", "@planetscale/database": ">=1.13", "@prisma/client": "*", "@tidbcloud/serverless": "*", "@types/better-sqlite3": "*", "@types/pg": "*", "@types/sql.js": "*", "@upstash/redis": ">=1.34.7", "@vercel/postgres": ">=0.8.0", "@xata.io/client": "*", "better-sqlite3": ">=7", "bun-types": "*", "expo-sqlite": ">=14.0.0", "gel": ">=2", "knex": "*", "kysely": "*", "mysql2": ">=2", "pg": ">=8", "postgres": ">=3", "sql.js": ">=1", "sqlite3": ">=5" }, "optionalPeers": ["@aws-sdk/client-rds-data", "@cloudflare/workers-types", "@electric-sql/pglite", "@libsql/client", "@libsql/client-wasm", "@neondatabase/serverless", "@op-engineering/op-sqlite", "@opentelemetry/api", "@planetscale/database", "@prisma/client", "@tidbcloud/serverless", "@types/better-sqlite3", "@types/pg", "@types/sql.js", "@upstash/redis", "@vercel/postgres", "@xata.io/client", "better-sqlite3", "bun-types", "expo-sqlite", "gel", "knex", "kysely", "mysql2", "pg", "postgres", "sql.js", "sqlite3"] }, "sha512-jBe37K7d8ZSKptdKfakQFdeljtu3P2Cbo7tJoJSVZADzIKOBo9IAJPOmMsH2bZl90bZgh8FQlD8BjxXA/zuBkQ=="],
 
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 
@@ -983,6 +1053,10 @@
     "es-shim-unscopables": ["es-shim-unscopables@1.1.0", "", { "dependencies": { "hasown": "^2.0.2" } }, "sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw=="],
 
     "es-to-primitive": ["es-to-primitive@1.3.0", "", { "dependencies": { "is-callable": "^1.2.7", "is-date-object": "^1.0.5", "is-symbol": "^1.0.4" } }, "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g=="],
+
+    "esbuild": ["esbuild@0.25.10", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.10", "@esbuild/android-arm": "0.25.10", "@esbuild/android-arm64": "0.25.10", "@esbuild/android-x64": "0.25.10", "@esbuild/darwin-arm64": "0.25.10", "@esbuild/darwin-x64": "0.25.10", "@esbuild/freebsd-arm64": "0.25.10", "@esbuild/freebsd-x64": "0.25.10", "@esbuild/linux-arm": "0.25.10", "@esbuild/linux-arm64": "0.25.10", "@esbuild/linux-ia32": "0.25.10", "@esbuild/linux-loong64": "0.25.10", "@esbuild/linux-mips64el": "0.25.10", "@esbuild/linux-ppc64": "0.25.10", "@esbuild/linux-riscv64": "0.25.10", "@esbuild/linux-s390x": "0.25.10", "@esbuild/linux-x64": "0.25.10", "@esbuild/netbsd-arm64": "0.25.10", "@esbuild/netbsd-x64": "0.25.10", "@esbuild/openbsd-arm64": "0.25.10", "@esbuild/openbsd-x64": "0.25.10", "@esbuild/openharmony-arm64": "0.25.10", "@esbuild/sunos-x64": "0.25.10", "@esbuild/win32-arm64": "0.25.10", "@esbuild/win32-ia32": "0.25.10", "@esbuild/win32-x64": "0.25.10" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-9RiGKvCwaqxO2owP61uQ4BgNborAQskMR6QusfWzQqv7AZOg5oGehdY2pRJMTKuwxd1IDBP4rSbI5lHzU7SMsQ=="],
+
+    "esbuild-register": ["esbuild-register@3.6.0", "", { "dependencies": { "debug": "^4.3.4" }, "peerDependencies": { "esbuild": ">=0.12 <1" } }, "sha512-H2/S7Pm8a9CL1uhp9OvjwrBh5Pvx0H8qVOxNu8Wed9Y7qv56MPtq+GGM8RJpq6glYJn9Wspr8uw7l55uyinNeg=="],
 
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 
@@ -1540,6 +1614,22 @@
 
     "path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
 
+    "pg": ["pg@8.16.3", "", { "dependencies": { "pg-connection-string": "^2.9.1", "pg-pool": "^3.10.1", "pg-protocol": "^1.10.3", "pg-types": "2.2.0", "pgpass": "1.0.5" }, "optionalDependencies": { "pg-cloudflare": "^1.2.7" }, "peerDependencies": { "pg-native": ">=3.0.1" }, "optionalPeers": ["pg-native"] }, "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw=="],
+
+    "pg-cloudflare": ["pg-cloudflare@1.2.7", "", {}, "sha512-YgCtzMH0ptvZJslLM1ffsY4EuGaU0cx4XSdXLRFae8bPP4dS5xL1tNB3k2o/N64cHJpwU7dxKli/nZ2lUa5fLg=="],
+
+    "pg-connection-string": ["pg-connection-string@2.9.1", "", {}, "sha512-nkc6NpDcvPVpZXxrreI/FOtX3XemeLl8E0qFr6F2Lrm/I8WOnaWNhIPK2Z7OHpw7gh5XJThi6j6ppgNoaT1w4w=="],
+
+    "pg-int8": ["pg-int8@1.0.1", "", {}, "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw=="],
+
+    "pg-pool": ["pg-pool@3.10.1", "", { "peerDependencies": { "pg": ">=8.0" } }, "sha512-Tu8jMlcX+9d8+QVzKIvM/uJtp07PKr82IUOYEphaWcoBhIYkoHpLXN3qO59nAI11ripznDsEzEv8nUxBVWajGg=="],
+
+    "pg-protocol": ["pg-protocol@1.10.3", "", {}, "sha512-6DIBgBQaTKDJyxnXaLiLR8wBpQQcGWuAESkRBX/t6OwA8YsqP+iVSiond2EDy6Y/dsGk8rh/jtax3js5NeV7JQ=="],
+
+    "pg-types": ["pg-types@2.2.0", "", { "dependencies": { "pg-int8": "1.0.1", "postgres-array": "~2.0.0", "postgres-bytea": "~1.0.0", "postgres-date": "~1.0.4", "postgres-interval": "^1.1.0" } }, "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA=="],
+
+    "pgpass": ["pgpass@1.0.5", "", { "dependencies": { "split2": "^4.1.0" } }, "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug=="],
+
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
     "picomatch": ["picomatch@3.0.1", "", {}, "sha512-I3EurrIQMlRc9IaAZnqRR044Phh2DXY+55o7uJ0V+hYZAcQYSuFWsc9q5PvyDHUSCe1Qxn/iBz+78s86zWnGag=="],
@@ -1555,6 +1645,14 @@
     "postcss": ["postcss@8.4.49", "", { "dependencies": { "nanoid": "^3.3.7", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA=="],
 
     "postcss-value-parser": ["postcss-value-parser@4.2.0", "", {}, "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="],
+
+    "postgres-array": ["postgres-array@2.0.0", "", {}, "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA=="],
+
+    "postgres-bytea": ["postgres-bytea@1.0.0", "", {}, "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w=="],
+
+    "postgres-date": ["postgres-date@1.0.7", "", {}, "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q=="],
+
+    "postgres-interval": ["postgres-interval@1.2.0", "", { "dependencies": { "xtend": "^4.0.0" } }, "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ=="],
 
     "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
 
@@ -1738,6 +1836,8 @@
 
     "split-on-first": ["split-on-first@1.1.0", "", {}, "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw=="],
 
+    "split2": ["split2@4.2.0", "", {}, "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="],
+
     "sprintf-js": ["sprintf-js@1.0.3", "", {}, "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="],
 
     "stable-hash": ["stable-hash@0.0.5", "", {}, "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA=="],
@@ -1831,6 +1931,8 @@
     "tsconfig-paths": ["tsconfig-paths@3.15.0", "", { "dependencies": { "@types/json5": "^0.0.29", "json5": "^1.0.2", "minimist": "^1.2.6", "strip-bom": "^3.0.0" } }, "sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "tsx": ["tsx@4.20.5", "", { "dependencies": { "esbuild": "~0.25.0", "get-tsconfig": "^4.7.5" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-+wKjMNU9w/EaQayHXb7WA7ZaHY6hN8WgfvHNQ3t1PnU91/7O8TcTnIhCDYTZwnt8JsO9IBqZ30Ln1r7pPF52Aw=="],
 
     "turbo": ["turbo@2.5.6", "", { "optionalDependencies": { "turbo-darwin-64": "2.5.6", "turbo-darwin-arm64": "2.5.6", "turbo-linux-64": "2.5.6", "turbo-linux-arm64": "2.5.6", "turbo-windows-64": "2.5.6", "turbo-windows-arm64": "2.5.6" }, "bin": { "turbo": "bin/turbo" } }, "sha512-gxToHmi9oTBNB05UjUsrWf0OyN5ZXtD0apOarC1KIx232Vp3WimRNy3810QzeNSgyD5rsaIDXlxlbnOzlouo+w=="],
 
@@ -1956,6 +2058,8 @@
 
     "xmlbuilder": ["xmlbuilder@15.1.1", "", {}, "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg=="],
 
+    "xtend": ["xtend@4.0.2", "", {}, "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="],
+
     "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
 
     "yallist": ["yallist@5.0.0", "", {}, "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw=="],
@@ -1983,6 +2087,8 @@
     "@babel/traverse/@babel/code-frame": ["@babel/code-frame@7.27.1", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.27.1", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg=="],
 
     "@babel/traverse--for-generate-function-map/@babel/code-frame": ["@babel/code-frame@7.27.1", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.27.1", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg=="],
+
+    "@esbuild-kit/core-utils/esbuild": ["esbuild@0.18.20", "", { "optionalDependencies": { "@esbuild/android-arm": "0.18.20", "@esbuild/android-arm64": "0.18.20", "@esbuild/android-x64": "0.18.20", "@esbuild/darwin-arm64": "0.18.20", "@esbuild/darwin-x64": "0.18.20", "@esbuild/freebsd-arm64": "0.18.20", "@esbuild/freebsd-x64": "0.18.20", "@esbuild/linux-arm": "0.18.20", "@esbuild/linux-arm64": "0.18.20", "@esbuild/linux-ia32": "0.18.20", "@esbuild/linux-loong64": "0.18.20", "@esbuild/linux-mips64el": "0.18.20", "@esbuild/linux-ppc64": "0.18.20", "@esbuild/linux-riscv64": "0.18.20", "@esbuild/linux-s390x": "0.18.20", "@esbuild/linux-x64": "0.18.20", "@esbuild/netbsd-x64": "0.18.20", "@esbuild/openbsd-x64": "0.18.20", "@esbuild/sunos-x64": "0.18.20", "@esbuild/win32-arm64": "0.18.20", "@esbuild/win32-ia32": "0.18.20", "@esbuild/win32-x64": "0.18.20" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA=="],
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
@@ -2084,6 +2190,8 @@
 
     "@types/graceful-fs/@types/node": ["@types/node@22.18.6", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-r8uszLPpeIWbNKtvWRt/DbVi5zbqZyj1PTmhRMqBMvDnaz1QpmSKujUtJLrqGZeoM8v72MfYggDceY4K1itzWQ=="],
 
+    "@types/pg/@types/node": ["@types/node@22.18.6", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-r8uszLPpeIWbNKtvWRt/DbVi5zbqZyj1PTmhRMqBMvDnaz1QpmSKujUtJLrqGZeoM8v72MfYggDceY4K1itzWQ=="],
+
     "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
     "@typescript-eslint/typescript-estree/fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
@@ -2131,6 +2239,8 @@
     "eslint-module-utils/debug": ["debug@3.2.7", "", { "dependencies": { "ms": "^2.1.1" } }, "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ=="],
 
     "eslint-plugin-import/debug": ["debug@3.2.7", "", { "dependencies": { "ms": "^2.1.1" } }, "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ=="],
+
+    "eslint-plugin-turbo/dotenv": ["dotenv@16.0.3", "", {}, "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ=="],
 
     "expo-modules-autolinking/commander": ["commander@7.2.0", "", {}, "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="],
 
@@ -2271,6 +2381,50 @@
     "@babel/highlight/chalk/escape-string-regexp": ["escape-string-regexp@1.0.5", "", {}, "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="],
 
     "@babel/highlight/chalk/supports-color": ["supports-color@5.5.0", "", { "dependencies": { "has-flag": "^3.0.0" } }, "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.18.20", "", { "os": "android", "cpu": "arm" }, "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.18.20", "", { "os": "android", "cpu": "arm64" }, "sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.18.20", "", { "os": "android", "cpu": "x64" }, "sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.18.20", "", { "os": "darwin", "cpu": "arm64" }, "sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.18.20", "", { "os": "darwin", "cpu": "x64" }, "sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.18.20", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.18.20", "", { "os": "freebsd", "cpu": "x64" }, "sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.18.20", "", { "os": "linux", "cpu": "arm" }, "sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.18.20", "", { "os": "linux", "cpu": "arm64" }, "sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.18.20", "", { "os": "linux", "cpu": "ia32" }, "sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.18.20", "", { "os": "linux", "cpu": "none" }, "sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.18.20", "", { "os": "linux", "cpu": "none" }, "sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.18.20", "", { "os": "linux", "cpu": "ppc64" }, "sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.18.20", "", { "os": "linux", "cpu": "none" }, "sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.18.20", "", { "os": "linux", "cpu": "s390x" }, "sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.18.20", "", { "os": "linux", "cpu": "x64" }, "sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.18.20", "", { "os": "none", "cpu": "x64" }, "sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.18.20", "", { "os": "openbsd", "cpu": "x64" }, "sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.18.20", "", { "os": "sunos", "cpu": "x64" }, "sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.18.20", "", { "os": "win32", "cpu": "arm64" }, "sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.18.20", "", { "os": "win32", "cpu": "ia32" }, "sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.18.20", "", { "os": "win32", "cpu": "x64" }, "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ=="],
 
     "@expo/cli/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -12,6 +12,7 @@
     "apps/api": {
       "name": "api",
       "dependencies": {
+        "better-auth": "^1.3.13",
         "dotenv": "^17.2.2",
         "drizzle-orm": "^0.44.5",
         "hono": "^4.9.8",
@@ -296,6 +297,10 @@
 
     "@babel/types": ["@babel/types@7.28.4", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.27.1" } }, "sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q=="],
 
+    "@better-auth/utils": ["@better-auth/utils@0.3.0", "", {}, "sha512-W+Adw6ZA6mgvnSnhOki270rwJ42t4XzSK6YWGF//BbVXL6SwCLWfyzBc1lN2m/4RM28KubdBKQ4X5VMoLRNPQw=="],
+
+    "@better-fetch/fetch": ["@better-fetch/fetch@1.1.18", "", {}, "sha512-rEFOE1MYIsBmoMJtQbl32PGHHXuG2hDxvEd7rUHE0vCBoFQVSDqaVs9hkZEtHCxRoY+CljXKFCOuJ8uxqw1LcA=="],
+
     "@drizzle-team/brocli": ["@drizzle-team/brocli@0.10.2", "", {}, "sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w=="],
 
     "@egjs/hammerjs": ["@egjs/hammerjs@2.0.17", "", { "dependencies": { "@types/hammerjs": "^2.0.36" } }, "sha512-XQsZgjm2EcVUiZQf11UBJQfmZeEmOW8DpI1gsFeln6w0ae0ii4dMQEQ0kjl6DspdWX1aGY1/loyXnP0JS06e/A=="],
@@ -434,6 +439,8 @@
 
     "@expo/xcpretty": ["@expo/xcpretty@4.3.2", "", { "dependencies": { "@babel/code-frame": "7.10.4", "chalk": "^4.1.0", "find-up": "^5.0.0", "js-yaml": "^4.1.0" }, "bin": { "excpretty": "build/cli.js" } }, "sha512-ReZxZ8pdnoI3tP/dNnJdnmAk7uLT4FjsKDGW7YeDdvdOMz2XCQSmSCM9IWlrXuWtMF9zeSB6WJtEhCQ41gQOfw=="],
 
+    "@hexagon/base64": ["@hexagon/base64@1.1.28", "", {}, "sha512-lhqDEAvWixy3bZ+UOYbPwUbBkwBq5C1LAJ/xPC8Oi+lL54oyakv/npbA0aU2hgCsx/1NUd4IBvV03+aUBWxerw=="],
+
     "@humanfs/core": ["@humanfs/core@0.19.1", "", {}, "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA=="],
 
     "@humanfs/node": ["@humanfs/node@0.16.7", "", { "dependencies": { "@humanfs/core": "^0.19.1", "@humanwhocodes/retry": "^0.4.0" } }, "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ=="],
@@ -522,6 +529,8 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
+    "@levischuck/tiny-cbor": ["@levischuck/tiny-cbor@0.2.11", "", {}, "sha512-llBRm4dT4Z89aRsm6u2oEZ8tfwL/2l6BwpZ7JcyieouniDECM5AqNgr/y08zalEIvW3RSK4upYyybDcmjXqAow=="],
+
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@0.2.12", "", { "dependencies": { "@emnapi/core": "^1.4.3", "@emnapi/runtime": "^1.4.3", "@tybys/wasm-util": "^0.10.0" } }, "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ=="],
 
     "@next/env": ["@next/env@15.5.3", "", {}, "sha512-RSEDTRqyihYXygx/OJXwvVupfr9m04+0vH8vyy0HfZ7keRto6VX9BbEk0J2PUk0VGy6YhklJUSrgForov5F9pw=="],
@@ -544,6 +553,10 @@
 
     "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@15.5.3", "", { "os": "win32", "cpu": "x64" }, "sha512-JMoLAq3n3y5tKXPQwCK5c+6tmwkuFDa2XAxz8Wm4+IVthdBZdZGh+lmiLUHg9f9IDwIQpUjp+ysd6OkYTyZRZw=="],
 
+    "@noble/ciphers": ["@noble/ciphers@2.0.0", "", {}, "sha512-j/l6jpnpaIBM87cAYPJzi/6TgqmBv9spkqPyCXvRYsu5uxqh6tPJZDnD85yo8VWqzTuTQPgfv7NgT63u7kbwAQ=="],
+
+    "@noble/hashes": ["@noble/hashes@2.0.0", "", {}, "sha512-h8VUBlE8R42+XIDO229cgisD287im3kdY6nbNZJFjc6ZvKIXPYXe6Vc/t+kyjFdMFyt5JpapzTsEg8n63w5/lw=="],
+
     "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
 
     "@nodelib/fs.stat": ["@nodelib/fs.stat@2.0.5", "", {}, "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="],
@@ -551,6 +564,30 @@
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
 
     "@nolyfill/is-core-module": ["@nolyfill/is-core-module@1.0.39", "", {}, "sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA=="],
+
+    "@peculiar/asn1-android": ["@peculiar/asn1-android@2.5.0", "", { "dependencies": { "@peculiar/asn1-schema": "^2.5.0", "asn1js": "^3.0.6", "tslib": "^2.8.1" } }, "sha512-t8A83hgghWQkcneRsgGs2ebAlRe54ns88p7ouv8PW2tzF1nAW4yHcL4uZKrFpIU+uszIRzTkcCuie37gpkId0A=="],
+
+    "@peculiar/asn1-cms": ["@peculiar/asn1-cms@2.5.0", "", { "dependencies": { "@peculiar/asn1-schema": "^2.5.0", "@peculiar/asn1-x509": "^2.5.0", "@peculiar/asn1-x509-attr": "^2.5.0", "asn1js": "^3.0.6", "tslib": "^2.8.1" } }, "sha512-p0SjJ3TuuleIvjPM4aYfvYw8Fk1Hn/zAVyPJZTtZ2eE9/MIer6/18ROxX6N/e6edVSfvuZBqhxAj3YgsmSjQ/A=="],
+
+    "@peculiar/asn1-csr": ["@peculiar/asn1-csr@2.5.0", "", { "dependencies": { "@peculiar/asn1-schema": "^2.5.0", "@peculiar/asn1-x509": "^2.5.0", "asn1js": "^3.0.6", "tslib": "^2.8.1" } }, "sha512-ioigvA6WSYN9h/YssMmmoIwgl3RvZlAYx4A/9jD2qaqXZwGcNlAxaw54eSx2QG1Yu7YyBC5Rku3nNoHrQ16YsQ=="],
+
+    "@peculiar/asn1-ecc": ["@peculiar/asn1-ecc@2.5.0", "", { "dependencies": { "@peculiar/asn1-schema": "^2.5.0", "@peculiar/asn1-x509": "^2.5.0", "asn1js": "^3.0.6", "tslib": "^2.8.1" } }, "sha512-t4eYGNhXtLRxaP50h3sfO6aJebUCDGQACoeexcelL4roMFRRVgB20yBIu2LxsPh/tdW9I282gNgMOyg3ywg/mg=="],
+
+    "@peculiar/asn1-pfx": ["@peculiar/asn1-pfx@2.5.0", "", { "dependencies": { "@peculiar/asn1-cms": "^2.5.0", "@peculiar/asn1-pkcs8": "^2.5.0", "@peculiar/asn1-rsa": "^2.5.0", "@peculiar/asn1-schema": "^2.5.0", "asn1js": "^3.0.6", "tslib": "^2.8.1" } }, "sha512-Vj0d0wxJZA+Ztqfb7W+/iu8Uasw6hhKtCdLKXLG/P3kEPIQpqGI4P4YXlROfl7gOCqFIbgsj1HzFIFwQ5s20ug=="],
+
+    "@peculiar/asn1-pkcs8": ["@peculiar/asn1-pkcs8@2.5.0", "", { "dependencies": { "@peculiar/asn1-schema": "^2.5.0", "@peculiar/asn1-x509": "^2.5.0", "asn1js": "^3.0.6", "tslib": "^2.8.1" } }, "sha512-L7599HTI2SLlitlpEP8oAPaJgYssByI4eCwQq2C9eC90otFpm8MRn66PpbKviweAlhinWQ3ZjDD2KIVtx7PaVw=="],
+
+    "@peculiar/asn1-pkcs9": ["@peculiar/asn1-pkcs9@2.5.0", "", { "dependencies": { "@peculiar/asn1-cms": "^2.5.0", "@peculiar/asn1-pfx": "^2.5.0", "@peculiar/asn1-pkcs8": "^2.5.0", "@peculiar/asn1-schema": "^2.5.0", "@peculiar/asn1-x509": "^2.5.0", "@peculiar/asn1-x509-attr": "^2.5.0", "asn1js": "^3.0.6", "tslib": "^2.8.1" } }, "sha512-UgqSMBLNLR5TzEZ5ZzxR45Nk6VJrammxd60WMSkofyNzd3DQLSNycGWSK5Xg3UTYbXcDFyG8pA/7/y/ztVCa6A=="],
+
+    "@peculiar/asn1-rsa": ["@peculiar/asn1-rsa@2.5.0", "", { "dependencies": { "@peculiar/asn1-schema": "^2.5.0", "@peculiar/asn1-x509": "^2.5.0", "asn1js": "^3.0.6", "tslib": "^2.8.1" } }, "sha512-qMZ/vweiTHy9syrkkqWFvbT3eLoedvamcUdnnvwyyUNv5FgFXA3KP8td+ATibnlZ0EANW5PYRm8E6MJzEB/72Q=="],
+
+    "@peculiar/asn1-schema": ["@peculiar/asn1-schema@2.5.0", "", { "dependencies": { "asn1js": "^3.0.6", "pvtsutils": "^1.3.6", "tslib": "^2.8.1" } }, "sha512-YM/nFfskFJSlHqv59ed6dZlLZqtZQwjRVJ4bBAiWV08Oc+1rSd5lDZcBEx0lGDHfSoH3UziI2pXt2UM33KerPQ=="],
+
+    "@peculiar/asn1-x509": ["@peculiar/asn1-x509@2.5.0", "", { "dependencies": { "@peculiar/asn1-schema": "^2.5.0", "asn1js": "^3.0.6", "pvtsutils": "^1.3.6", "tslib": "^2.8.1" } }, "sha512-CpwtMCTJvfvYTFMuiME5IH+8qmDe3yEWzKHe7OOADbGfq7ohxeLaXwQo0q4du3qs0AII3UbLCvb9NF/6q0oTKQ=="],
+
+    "@peculiar/asn1-x509-attr": ["@peculiar/asn1-x509-attr@2.5.0", "", { "dependencies": { "@peculiar/asn1-schema": "^2.5.0", "@peculiar/asn1-x509": "^2.5.0", "asn1js": "^3.0.6", "tslib": "^2.8.1" } }, "sha512-9f0hPOxiJDoG/bfNLAFven+Bd4gwz/VzrCIIWc1025LEI4BXO0U5fOCTNDPbbp2ll+UzqKsZ3g61mpBp74gk9A=="],
+
+    "@peculiar/x509": ["@peculiar/x509@1.14.0", "", { "dependencies": { "@peculiar/asn1-cms": "^2.5.0", "@peculiar/asn1-csr": "^2.5.0", "@peculiar/asn1-ecc": "^2.5.0", "@peculiar/asn1-pkcs9": "^2.5.0", "@peculiar/asn1-rsa": "^2.5.0", "@peculiar/asn1-schema": "^2.5.0", "@peculiar/asn1-x509": "^2.5.0", "pvtsutils": "^1.3.6", "reflect-metadata": "^0.2.2", "tslib": "^2.8.1", "tsyringe": "^4.10.0" } }, "sha512-Yc4PDxN3OrxUPiXgU63c+ZRXKGE8YKF2McTciYhUHFtHVB0KMnjeFSU0qpztGhsp4P0uKix4+J2xEpIEDu8oXg=="],
 
     "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
 
@@ -637,6 +674,10 @@
     "@rtsao/scc": ["@rtsao/scc@1.1.0", "", {}, "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g=="],
 
     "@rushstack/eslint-patch": ["@rushstack/eslint-patch@1.12.0", "", {}, "sha512-5EwMtOqvJMMa3HbmxLlF74e+3/HhwBTMcvt3nqVJgGCozO6hzIPOBlwm8mGVNR9SN2IJpxSnlxczyDjcn7qIyw=="],
+
+    "@simplewebauthn/browser": ["@simplewebauthn/browser@13.2.0", "", {}, "sha512-N3fuA1AAnTo5gCStYoIoiasPccC+xPLx2YU88Dv0GeAmPQTWHETlZQq5xZ0DgUq1H9loXMWQH5qqUjcI7BHJ1A=="],
+
+    "@simplewebauthn/server": ["@simplewebauthn/server@13.2.1", "", { "dependencies": { "@hexagon/base64": "^1.1.27", "@levischuck/tiny-cbor": "^0.2.2", "@peculiar/asn1-android": "^2.3.10", "@peculiar/asn1-ecc": "^2.3.8", "@peculiar/asn1-rsa": "^2.3.8", "@peculiar/asn1-schema": "^2.3.8", "@peculiar/asn1-x509": "^2.3.8", "@peculiar/x509": "^1.13.0" } }, "sha512-Inmfye5opZXe3HI0GaksqBnQiM7glcNySoG6DH1GgkO1Lh9dvuV4XSV9DK02DReUVX39HpcDob9nxHELjECoQw=="],
 
     "@sinclair/typebox": ["@sinclair/typebox@0.27.8", "", {}, "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA=="],
 
@@ -836,6 +877,8 @@
 
     "asap": ["asap@2.0.6", "", {}, "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="],
 
+    "asn1js": ["asn1js@3.0.6", "", { "dependencies": { "pvtsutils": "^1.3.6", "pvutils": "^1.1.3", "tslib": "^2.8.1" } }, "sha512-UOCGPYbl0tv8+006qks/dTgV9ajs97X2p0FAbyS2iyCRrmLSRolDaHdp+v/CLgnzHc3fVB+CwYiUmei7ndFcgA=="],
+
     "ast-types-flow": ["ast-types-flow@0.0.8", "", {}, "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ=="],
 
     "async-function": ["async-function@1.0.0", "", {}, "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA=="],
@@ -879,6 +922,10 @@
     "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
 
     "baseline-browser-mapping": ["baseline-browser-mapping@2.8.6", "", { "bin": { "baseline-browser-mapping": "dist/cli.js" } }, "sha512-wrH5NNqren/QMtKUEEJf7z86YjfqW/2uw3IL3/xpqZUC95SSVIFXYQeeGjL6FT/X68IROu6RMehZQS5foy2BXw=="],
+
+    "better-auth": ["better-auth@1.3.13", "", { "dependencies": { "@better-auth/utils": "0.3.0", "@better-fetch/fetch": "^1.1.18", "@noble/ciphers": "^2.0.0", "@noble/hashes": "^2.0.0", "@simplewebauthn/browser": "^13.1.2", "@simplewebauthn/server": "^13.1.2", "better-call": "1.0.19", "defu": "^6.1.4", "jose": "^6.1.0", "kysely": "^0.28.5", "nanostores": "^1.0.1", "zod": "^4.1.5" }, "peerDependencies": { "@lynx-js/react": "*", "@sveltejs/kit": "^2.0.0", "next": "^14.0.0 || ^15.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0", "solid-js": "^1.0.0", "svelte": "^4.0.0 || ^5.0.0", "vue": "^3.0.0" }, "optionalPeers": ["@lynx-js/react", "@sveltejs/kit", "next", "react", "react-dom", "solid-js", "svelte", "vue"] }, "sha512-vNIVExB87JTM19+1+p6SZ6xbzZFLw4ug8ir61qCArE8UbIN3SZQi0T3/PjubpWPwsLjINBsVizeHxPf5S7Ss0A=="],
+
+    "better-call": ["better-call@1.0.19", "", { "dependencies": { "@better-auth/utils": "^0.3.0", "@better-fetch/fetch": "^1.1.4", "rou3": "^0.5.1", "set-cookie-parser": "^2.7.1", "uncrypto": "^0.1.3" } }, "sha512-sI3GcA1SCVa3H+CDHl8W8qzhlrckwXOTKhqq3OOPXjgn5aTOMIqGY34zLY/pHA6tRRMjTUC3lz5Mi7EbDA24Kw=="],
 
     "better-opn": ["better-opn@3.0.2", "", { "dependencies": { "open": "^8.0.4" } }, "sha512-aVNobHnJqLiUelTaHat9DZ1qM2w0C0Eym4LPI/3JxOnSokGVdsl1T1kN7TFvsEAD8G47A6VKQ0TVHqbBnYMJlQ=="],
 
@@ -999,6 +1046,8 @@
     "define-lazy-prop": ["define-lazy-prop@2.0.0", "", {}, "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og=="],
 
     "define-properties": ["define-properties@1.2.1", "", { "dependencies": { "define-data-property": "^1.0.1", "has-property-descriptors": "^1.0.0", "object-keys": "^1.1.1" } }, "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg=="],
+
+    "defu": ["defu@6.1.4", "", {}, "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg=="],
 
     "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
 
@@ -1386,6 +1435,8 @@
 
     "jiti": ["jiti@2.5.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-twQoecYPiVA5K/h6SxtORw/Bs3ar+mLUtoPSc7iMXzQzK8d7eJ/R09wmTwAjiamETn1cXYPGfNnu7DMoHgu12w=="],
 
+    "jose": ["jose@6.1.0", "", {}, "sha512-TTQJyoEoKcC1lscpVDCSsVgYzUDg/0Bt3WE//WiTPK6uOCQC2KZS4MpugbMWt/zyjkopgZoXhZuCi00gLudfUA=="],
+
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "js-yaml": ["js-yaml@4.1.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA=="],
@@ -1409,6 +1460,8 @@
     "keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
 
     "kleur": ["kleur@3.0.3", "", {}, "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="],
+
+    "kysely": ["kysely@0.28.7", "", {}, "sha512-u/cAuTL4DRIiO2/g4vNGRgklEKNIj5Q3CG7RoUB5DV5SfEC2hMvPxKi0GWPmnzwL2ryIeud2VTcEEmqzTzEPNw=="],
 
     "lan-network": ["lan-network@0.1.7", "", { "bin": { "lan-network": "dist/lan-network-cli.js" } }, "sha512-mnIlAEMu4OyEvUNdzco9xpuB9YVcPkQec+QsgycBCtPZvEqWPCDPfbAE4OJMdBBWpZWtpCn1xw9jJYlwjWI5zQ=="],
 
@@ -1529,6 +1582,8 @@
     "mz": ["mz@2.7.0", "", { "dependencies": { "any-promise": "^1.0.0", "object-assign": "^4.0.1", "thenify-all": "^1.0.0" } }, "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q=="],
 
     "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
+
+    "nanostores": ["nanostores@1.0.1", "", {}, "sha512-kNZ9xnoJYKg/AfxjrVL4SS0fKX++4awQReGqWnwTRHxeHGZ1FJFVgTqr/eMrNQdp0Tz7M7tG/TDaX8QfHDwVCw=="],
 
     "napi-postinstall": ["napi-postinstall@0.3.3", "", { "bin": { "napi-postinstall": "lib/cli.js" } }, "sha512-uTp172LLXSxuSYHv/kou+f6KW3SMppU9ivthaVTXian9sOt3XM/zHYHpRZiLgQoxeWfYUnslNWQHF1+G71xcow=="],
 
@@ -1674,6 +1729,10 @@
 
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
+    "pvtsutils": ["pvtsutils@1.3.6", "", { "dependencies": { "tslib": "^2.8.1" } }, "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg=="],
+
+    "pvutils": ["pvutils@1.1.3", "", {}, "sha512-pMpnA0qRdFp32b1sJl1wOJNxZLQ2cbQx+k6tjNtZ8CpvVhNqEPRgivZ2WOUev2YMajecdH7ctUPDvEe87nariQ=="],
+
     "qrcode-terminal": ["qrcode-terminal@0.11.0", "", { "bin": { "qrcode-terminal": "./bin/qrcode-terminal.js" } }, "sha512-Uu7ii+FQy4Qf82G4xu7ShHhjhGahEpCWc3x8UavY3CTcWV+ufmmCtwkr7ZKsX42jdL0kr1B5FKUeqJvAn51jzQ=="],
 
     "query-string": ["query-string@7.1.3", "", { "dependencies": { "decode-uri-component": "^0.2.2", "filter-obj": "^1.1.0", "split-on-first": "^1.0.0", "strict-uri-encode": "^2.0.0" } }, "sha512-hh2WYhq4fi8+b+/2Kg9CEge4fDPvHS534aOOvOZeQ3+Vf2mCFsaFBYj0i+iXcAq6I9Vzp5fjMFBlONvayDC1qg=="],
@@ -1722,6 +1781,8 @@
 
     "react-style-singleton": ["react-style-singleton@2.2.3", "", { "dependencies": { "get-nonce": "^1.0.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ=="],
 
+    "reflect-metadata": ["reflect-metadata@0.2.2", "", {}, "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q=="],
+
     "reflect.getprototypeof": ["reflect.getprototypeof@1.0.10", "", { "dependencies": { "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-abstract": "^1.23.9", "es-errors": "^1.3.0", "es-object-atoms": "^1.0.0", "get-intrinsic": "^1.2.7", "get-proto": "^1.0.1", "which-builtin-type": "^1.2.1" } }, "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw=="],
 
     "regenerate": ["regenerate@1.4.2", "", {}, "sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A=="],
@@ -1762,6 +1823,8 @@
 
     "rimraf": ["rimraf@3.0.2", "", { "dependencies": { "glob": "^7.1.3" }, "bin": { "rimraf": "bin.js" } }, "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA=="],
 
+    "rou3": ["rou3@0.5.1", "", {}, "sha512-OXMmJ3zRk2xeXFGfA3K+EOPHC5u7RDFG7lIOx0X1pdnhUkI8MdVrbV+sNsD80ElpUZ+MRHdyxPnFthq9VHs8uQ=="],
+
     "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
 
     "safe-array-concat": ["safe-array-concat@1.1.3", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.2", "get-intrinsic": "^1.2.6", "has-symbols": "^1.1.0", "isarray": "^2.0.5" } }, "sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q=="],
@@ -1785,6 +1848,8 @@
     "serve-static": ["serve-static@1.16.2", "", { "dependencies": { "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "parseurl": "~1.3.3", "send": "0.19.0" } }, "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw=="],
 
     "server-only": ["server-only@0.0.1", "", {}, "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA=="],
+
+    "set-cookie-parser": ["set-cookie-parser@2.7.1", "", {}, "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ=="],
 
     "set-function-length": ["set-function-length@1.2.2", "", { "dependencies": { "define-data-property": "^1.1.4", "es-errors": "^1.3.0", "function-bind": "^1.1.2", "get-intrinsic": "^1.2.4", "gopd": "^1.0.1", "has-property-descriptors": "^1.0.2" } }, "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg=="],
 
@@ -1934,6 +1999,8 @@
 
     "tsx": ["tsx@4.20.5", "", { "dependencies": { "esbuild": "~0.25.0", "get-tsconfig": "^4.7.5" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-+wKjMNU9w/EaQayHXb7WA7ZaHY6hN8WgfvHNQ3t1PnU91/7O8TcTnIhCDYTZwnt8JsO9IBqZ30Ln1r7pPF52Aw=="],
 
+    "tsyringe": ["tsyringe@4.10.0", "", { "dependencies": { "tslib": "^1.9.3" } }, "sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw=="],
+
     "turbo": ["turbo@2.5.6", "", { "optionalDependencies": { "turbo-darwin-64": "2.5.6", "turbo-darwin-arm64": "2.5.6", "turbo-linux-64": "2.5.6", "turbo-linux-arm64": "2.5.6", "turbo-windows-64": "2.5.6", "turbo-windows-arm64": "2.5.6" }, "bin": { "turbo": "bin/turbo" } }, "sha512-gxToHmi9oTBNB05UjUsrWf0OyN5ZXtD0apOarC1KIx232Vp3WimRNy3810QzeNSgyD5rsaIDXlxlbnOzlouo+w=="],
 
     "turbo-darwin-64": ["turbo-darwin-64@2.5.6", "", { "os": "darwin", "cpu": "x64" }, "sha512-3C1xEdo4aFwMJAPvtlPqz1Sw/+cddWIOmsalHFMrsqqydcptwBfu26WW2cDm3u93bUzMbBJ8k3zNKFqxJ9ei2A=="],
@@ -1969,6 +2036,8 @@
     "ua-parser-js": ["ua-parser-js@1.0.41", "", { "bin": { "ua-parser-js": "script/cli.js" } }, "sha512-LbBDqdIC5s8iROCUjMbW1f5dJQTEFB1+KO9ogbvlb3nm9n4YHa5p4KTvFPWvh2Hs8gZMBuiB1/8+pdfe/tDPug=="],
 
     "unbox-primitive": ["unbox-primitive@1.1.0", "", { "dependencies": { "call-bound": "^1.0.3", "has-bigints": "^1.0.2", "has-symbols": "^1.1.0", "which-boxed-primitive": "^1.1.1" } }, "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw=="],
+
+    "uncrypto": ["uncrypto@0.1.3", "", {}, "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q=="],
 
     "undici": ["undici@6.21.3", "", {}, "sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw=="],
 
@@ -2072,7 +2141,7 @@
 
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 
-    "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+    "zod": ["zod@4.1.11", "", {}, "sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg=="],
 
     "zod-to-json-schema": ["zod-to-json-schema@3.24.6", "", { "peerDependencies": { "zod": "^3.24.1" } }, "sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg=="],
 
@@ -2127,6 +2196,8 @@
     "@expo/image-utils/semver": ["semver@7.7.2", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="],
 
     "@expo/mcp-tunnel/ws": ["ws@8.18.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg=="],
+
+    "@expo/mcp-tunnel/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "@expo/metro/metro-runtime": ["metro-runtime@0.83.1", "", { "dependencies": { "@babel/runtime": "^7.25.0", "flow-enums-runtime": "^0.0.6" } }, "sha512-3Ag8ZS4IwafL/JUKlaeM6/CbkooY+WcVeqdNlBG0m4S0Qz0om3rdFdy1y6fYBpl6AwXJwWeMuXrvZdMuByTcRA=="],
 
@@ -2366,6 +2437,8 @@
 
     "tsconfig-paths/json5": ["json5@1.0.2", "", { "dependencies": { "minimist": "^1.2.0" }, "bin": { "json5": "lib/cli.js" } }, "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA=="],
 
+    "tsyringe/tslib": ["tslib@1.14.1", "", {}, "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="],
+
     "whatwg-url/webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
 
     "wrap-ansi/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
@@ -2375,6 +2448,8 @@
     "write-file-atomic/signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
 
     "xml2js/xmlbuilder": ["xmlbuilder@11.0.1", "", {}, "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="],
+
+    "zod-to-json-schema/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "@babel/highlight/chalk/ansi-styles": ["ansi-styles@3.2.1", "", { "dependencies": { "color-convert": "^1.9.0" } }, "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA=="],
 

--- a/docs/hairfluencer-PRD.md
+++ b/docs/hairfluencer-PRD.md
@@ -1,0 +1,399 @@
+# Hairfluencer – AI Hairstyle Try On (Hackathon MVP)
+
+### TL;DR
+
+Hairfluencer – AI Hairstyle Try On empowers anyone to instantly visualize new haircuts and colors using AI from a simple selfie. Built for fast, hackathon-grade launch, it offers quick onboarding, instant transformations, and dual-language support—making advanced style try-ons accessible to everyday users seeking inspiration and confidence in their next look.
+
+---
+
+## Goals
+
+### Business Goals
+
+* Launch a working MVP within 14 days to showcase at the hackathon.
+
+* Achieve at least 200 user sign-ups and 100 completed try-ons within the first week.
+
+* Validate user interest by tracking conversion from first visit to try-on (\~20%+ rate).
+
+* Collect actionable user feedback (minimum 50 survey responses).
+
+* Establish baseline analytics for future iterations and investor demos.
+
+### User Goals
+
+* Instantly see themselves with new hairstyles in a lifelike and realistic way.
+
+* Quickly experiment with different haircuts/colors before making real-world decisions.
+
+* Easily save and revisit favorite AI-generated hairstyle results.
+
+* Use the app in their preferred language (English or Spanish) for maximum accessibility.
+
+* Experience a private, no-pressure space to explore new styles confidently.
+
+### Non-Goals
+
+* No support for fine-tuned, face-specific AI customization (out-of-scope for MVP).
+
+* No direct sharing to social networks or export/download of results in this version.
+
+* No integration with booking stylists or e-commerce links.
+
+* No in-app purchases or monetization implemented in MVP.
+
+---
+
+## User Stories
+
+**Persona 1: Everyday User (Hairstyle Seeker)**
+
+* As a user, I want to upload a selfie, so that I can see new hairstyles on myself.
+
+* As a user, I want to browse a gallery of trending hairstyles, so that I’m inspired when picking a style.
+
+* As a user, I want to try multiple styles quickly, so that I can compare results and find my favorite.
+
+* As a user, I want to mark favorite results, so that I can come back to them later.
+
+* As a user, I want to use the app in my preferred language (English or Spanish), so that I can easily understand and navigate.
+
+**Persona 2: Admin**
+
+* As an admin, I want to add and remove hairstyles from the gallery, so that offerings stay fresh and varied.
+
+* As an admin, I want to view usage stats, so that I can assess popular styles and overall engagement.
+
+* As an admin, I want to moderate inappropriate photos or report IF required, ensuring a safe experience.
+
+---
+
+## Functional Requirements
+
+* **Authentication & User Accounts** (Priority: High)
+
+  * Email/password sign-up and login.
+
+  * Social login (Google) as a backup option (if feasible in 14 days).
+
+  * Password reset via email.
+
+  * Basic account management (language setting).
+
+* **Photo Upload & Management** (Priority: High)
+
+  * Upload selfie from device camera or gallery.
+
+  * Automatic photo validation (face detection, minimum quality).
+
+  * Secure temporary storage of uploads.
+
+* **Hairstyle Gallery** (Priority: High)
+
+  * Browse list/grid of available hairstyle options with images/tags.
+
+  * Dual-language descriptions/tags for styles.
+
+  * Admin panel for gallery management (add/remove styles).
+
+* **AI Hairstyle Generation** (Priority: High)
+
+  * Connect to Nano Bana Image AI via API for real-time generation.
+
+  * Pass photo and style selection to backend, return transformed result.
+
+  * Retry/requeue gracefully if AI fails.
+
+* **Favorites & Gallery Management** (Priority: Medium)
+
+  * "Favorite" button to save AI results.
+
+  * Personal gallery view for saved/favorited try-ons.
+
+* **Localization / Language Switching** (Priority: Medium)
+
+  * UI toggle between English and Spanish.
+
+  * All core flows, labels, error messages available in both languages.
+
+* **Analytics & Feedback Collection** (Priority: Medium)
+
+  * Track key funnel events and errors (see Tracking Plan below).
+
+  * Simple feedback prompt after try-on for user comments.
+
+---
+
+## User Experience
+
+**Entry Point & First-Time User Experience**
+
+* User discovers Hairfluencer via hackathon, social media, or QR code.
+
+* Arrives on a welcoming landing screen, emphasizing "Try on any hairstyle in seconds."
+
+* Presented with language select (English/Spanish) if system language is ambiguous.
+
+* Simple sign-up or login screen, with clear privacy note and "no photos saved/shared" reassurance.
+
+* Onboarding modal or quick tutorial explains steps: 1) Upload selfie, 2) Choose hairstyle, 3) See your new look!
+
+**Core Experience**
+
+* **Step 1:** User lands on home/dashboard after sign-in.
+
+  * Prominent call-to-action to "Try a New Style."
+
+  * Minimal distractions; easy for first-timers to understand.
+
+* **Step 2:** Upload photo (camera or pick from gallery).
+
+  * Face detection validates image; user is guided if invalid.
+
+  * Shows preview, with option to retake or proceed.
+
+* **Step 3:** Browse hairstyle gallery.
+
+  * Grid of styles, each with name/tag (bilingual).
+
+  * Tap to select and see more info, or "Try On" immediately.
+
+* **Step 4:** AI hairstyle processing.
+
+  * Animated loader/modal explains "Working our magic…"
+
+  * Progress feedback, with retry suggestions if delay/error.
+
+* **Step 5:** Result display.
+
+  * Side-by-side or toggle between "before" and "after."
+
+  * Options: "Favorite," "Try Another Style," "Return to Gallery."
+
+* **Step 6:** Favorites gallery.
+
+  * User can revisit all saved looks.
+
+  * Remove from favorites as desired.
+
+* **Step 7:** Feedback prompt.
+
+  * Brief popup or banner: "Was this helpful?" (star rating/comments).
+
+**Advanced Features & Edge Cases**
+
+* If AI API fails or is slow, clear error message and retry logic.
+
+* Handle photos with multiple/few faces gracefully.
+
+* Admin-only interface is separate/simple: add/remove style images, basic stats view.
+
+* Accessibility: supports colorblind-friendly palette & keyboard navigation.
+
+**UI/UX Highlights**
+
+* Mobile-first responsive design.
+
+* High-contrast colors and large tappable areas.
+
+* Clear translation toggle/button.
+
+* Consistent confirmation dialogs for sensitive actions (delete, clear, etc.).
+
+* Friendly error states and gentle nudges for invalid input.
+
+---
+
+## Narrative
+
+Maya always struggled to picture herself with a bold new haircut. She’d browse Pinterest for ideas but never felt confident she’d actually like the change. One evening, her friend sends a link to Hairfluencer – an app promising instant, AI-powered hairstyle try-ons. Curious, Maya signs up and is greeted by a clean, inviting interface in her native Spanish. She uploads a quick selfie and is instantly wowed by the trendy styles in the gallery.
+
+In just seconds, she’s seeing herself with a chic pixie cut—a look she’d never have dared consider. She marks her favorites and compares them with her current look, feeling a genuine spark of excitement and possibility. No more guesswork, no stress—just a sense of control and fun. After a mini gallery of saved transformations, Maya is finally ready for her next salon visit, confident she’ll love the result.
+
+For Hairfluencer, empowering Maya means more than just digital novelty—it builds trust, engagement, and word-of-mouth momentum that’s priceless for growth.
+
+---
+
+## Success Metrics
+
+### User-Centric Metrics
+
+* Number of new user sign-ups per day.
+
+* Percentage of users who complete at least one AI try-on.
+
+* Average number of try-ons per active user.
+
+* Favoriting rate (% of results favorited).
+
+* Average user feedback score (1-5 stars).
+
+### Business Metrics
+
+* Sign-up to conversion funnel drop-off.
+
+* Total number of AI transformations generated.
+
+* Retention rate after day 1 and day 7.
+
+* Volume of feedback collected for feature prioritization.
+
+### Technical Metrics
+
+* API response time for AI transformations (<8 seconds, 90th percentile).
+
+* AI process success/error rate (<5% error rate).
+
+* App availability (99% during hackathon showcase period).
+
+* Photo upload success/failure logs.
+
+### Tracking Plan
+
+* User registration event.
+
+* Photo upload event.
+
+* Try-on initiation/completion.
+
+* Error/timeout events.
+
+* Favorite/unfavorite action.
+
+* Language toggle usage.
+
+* Feedback submission event.
+
+---
+
+## Technical Considerations
+
+### Technical Needs
+
+* **APIs:** REST API for authentication, photo upload, hairstyle gallery, AI processing, and favorites management.
+
+* **Frontend:** Mobile-responsive web app or lightweight cross-platform mobile app.
+
+* **Backend:** Orchestration server for API aggregation, user management, and interfacing with Nano Bana Image AI.
+
+* **Admin Panel:** Lightweight web interface, authentication-protected, for style/gallery management.
+
+* **Localization:** Bilingual UI string resources, easy toggle.
+
+### Integration Points
+
+* Nano Bana Image AI external API for image transformation.
+
+* Email provider for sign-up, password reset flows.
+
+### Data Storage & Privacy
+
+* Temporary cloud storage for uploaded photos; auto-delete after session or fixed time.
+
+* Minimal user data (only essential info: email, hashed password).
+
+* GDPR/CCPA-compliant handling—explicit consent for photo use, data retention policy stated in onboarding.
+
+* No persistent storage of generated results for non-favorited items.
+
+### Scalability & Performance
+
+* Designed to serve 1,000+ concurrent sessions during hackathon peak.
+
+* Asynchronous processing of AI calls with polling for results.
+
+* Progressive fallbacks for slow/unavailable AI service.
+
+### Potential Challenges
+
+* Robustly handling AI API errors, timeouts, or degraded performance.
+
+* Ensuring privacy and rapid deletion of uploaded images.
+
+* Accurate dual-language support in all user flows.
+
+* Simple but secure admin separation from main interface.
+
+---
+
+## Milestones & Sequencing
+
+### Project Estimate
+
+* Medium: 2–4 weeks(Hackathon MVP to be delivered in 14 days)
+
+### Team Size & Composition
+
+* Medium Team: 3–5 people total
+
+  * 1 Product/Design (UX flows, onboarding, admin panel)
+
+  * 2 Frontend Engineers (app & responsive UI, localization)
+
+  * 1 Backend/API Engineer (user/accounts, AI orchestration, admin tools)
+
+  * 1 AI/API Integration/DevOps (Nano Bana AI hookup, image flow, deployment)
+
+### Suggested Phases
+
+**Phase 1: Foundation & AI Integration (Days 1–4)**
+
+* Key Deliverables:
+
+  * Set up repo, CI/CD, basic project scaffolding (All)
+
+  * User authentication API + frontend flow (Backend, Frontend)
+
+  * Nano Bana Image AI API connection with dummy workflow (AI Int.)
+
+  * Initial language select, onboarding screens (Product, Frontend)
+
+* Dependencies:
+
+  * Nano Bana AI dev/test credentials, design assets for core flows
+
+**Phase 2: Core Flows & Gallery (Days 5–9)**
+
+* Key Deliverables:
+
+  * Photo upload/validation, gallery browsing (Frontend, Backend)
+
+  * Main AI try-on flow live (All)
+
+  * Admin interface (Backend, Product)
+
+  * Dual-language full coverage in UI (Frontend, Product)
+
+* Dependencies:
+
+  * Full hairstyle gallery asset upload, error messages in both languages
+
+**Phase 3: Favorites, Analytics & Polishing (Days 10–12)**
+
+* Key Deliverables:
+
+  * Favorites "heart," personal gallery, remove favorite (Frontend)
+
+  * Core analytics funnel, basic error logging (Backend)
+
+  * UI pass: accessibility, color contrast, responsive tweaks (Product, Frontend)
+
+* Dependencies:
+
+  * Tracking/analytics config, bug reports
+
+**Phase 4: Testing, Edge Cases & Launch (Days 13–14)**
+
+* Key Deliverables:
+
+  * Test: multi-device/browsers, language switching, onboarding
+
+  * Final AI API reliability & error handling
+
+  * Prepare demo content, admin handover, and documentation
+
+* Dependencies:
+
+  * Dedicated time for user acceptance testing and bugfixes
+
+---

--- a/package.json
+++ b/package.json
@@ -20,5 +20,8 @@
   "workspaces": [
     "apps/*",
     "packages/*"
-  ]
+  ],
+  "dependencies": {
+    "hono": "^4.9.8"
+  }
 }

--- a/todos/auth-integration-improvements.md
+++ b/todos/auth-integration-improvements.md
@@ -1,0 +1,292 @@
+# Better Auth Integration - Code Review Findings & Improvements
+
+**PR #1**: Add Better Auth integration with Drizzle ORM
+**Date**: 2025-09-21
+**Status**: Ready to merge with follow-up improvements needed
+
+## 🎯 Priority Actions
+
+### High Priority (Security & Stability)
+
+#### 1. Environment Variable Validation
+**Issue**: Missing runtime validation for required environment variables
+**Risk**: Application may crash or behave unexpectedly if env vars are missing
+**Location**: `apps/api/src/auth.ts`, `apps/api/src/db/index.ts`
+
+**Solution**:
+```typescript
+// apps/api/src/auth.ts
+const requiredEnvVars = {
+  BETTER_AUTH_SECRET: process.env.BETTER_AUTH_SECRET,
+  BETTER_AUTH_URL: process.env.BETTER_AUTH_URL,
+  DATABASE_URL: process.env.DATABASE_URL
+};
+
+for (const [key, value] of Object.entries(requiredEnvVars)) {
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${key}`);
+  }
+}
+
+// Validate secret strength
+if (process.env.BETTER_AUTH_SECRET.length < 32) {
+  throw new Error('BETTER_AUTH_SECRET must be at least 32 characters');
+}
+```
+
+#### 2. Database Connection Error Handling
+**Issue**: Database connection errors may expose sensitive connection strings
+**Risk**: Security vulnerability through error messages
+**Location**: `apps/api/src/db/index.ts`
+
+**Solution**:
+```typescript
+import { drizzle } from 'drizzle-orm/node-postgres';
+import { Pool } from 'pg';
+import * as schema from './schemas';
+
+const pool = new Pool({
+  connectionString: process.env.DATABASE_URL,
+});
+
+// Add connection error handling
+pool.on('error', (err) => {
+  console.error('Database connection error:', err.message);
+  // Don't log the full error object which might contain connection string
+});
+
+export const db = drizzle(pool, { schema });
+```
+
+#### 3. Session Security Configuration
+**Issue**: No explicit session expiration or security settings
+**Risk**: Sessions may persist indefinitely or lack security features
+**Location**: `apps/api/src/auth.ts`
+
+**Solution**:
+```typescript
+export const auth = betterAuth({
+  database: drizzleAdapter(db, {
+    provider: "pg",
+  }),
+  emailAndPassword: {
+    enabled: true,
+    minPasswordLength: 8,
+    maxPasswordLength: 128,
+  },
+  session: {
+    expiresIn: 60 * 60 * 24 * 7,  // 7 days
+    updateAge: 60 * 60 * 24,       // Update session every 24 hours
+    cookieCache: {
+      enabled: true,
+      maxAge: 60 * 5,              // Cache for 5 minutes
+    },
+  },
+  security: {
+    rateLimit: {
+      window: 60,                  // 1 minute window
+      max: 10,                     // Max 10 requests per window
+    },
+  },
+  socialProviders: {
+    // Add social providers later if needed
+  },
+});
+```
+
+### Medium Priority (Production Readiness)
+
+#### 4. CORS Configuration
+**Issue**: Missing CORS configuration for auth routes
+**Risk**: Frontend may be unable to communicate with auth endpoints
+**Location**: `apps/api/src/index.ts`
+
+**Solution**:
+```typescript
+import { Hono } from 'hono'
+import { cors } from 'hono/cors'
+import { auth } from './auth'
+
+const app = new Hono()
+
+// Add CORS middleware
+app.use('/api/auth/*', cors({
+  origin: process.env.FRONTEND_URL || 'http://localhost:3000',
+  credentials: true,
+  allowMethods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
+  allowHeaders: ['Content-Type', 'Authorization'],
+}))
+
+app.get('/', (c) => {
+  return c.text('Hello Hono!')
+})
+
+// Mount Better Auth routes
+app.on(['POST', 'GET'], '/api/auth/*', (c) => {
+  return auth.handler(c.req.raw)
+})
+
+export default app
+```
+
+#### 5. Type Safety for Frontend
+**Issue**: No exported types for frontend consumption
+**Risk**: Type mismatches between backend and frontend
+**Location**: Create new file `apps/api/src/auth-types.ts`
+
+**Solution**:
+```typescript
+// apps/api/src/auth-types.ts
+import { auth } from './auth';
+import type { Session, User } from 'better-auth';
+
+export type AuthSession = Session;
+export type AuthUser = User;
+export type AuthClient = typeof auth.client;
+
+// Export for frontend usage
+export const authClientConfig = {
+  baseURL: process.env.BETTER_AUTH_URL || 'http://localhost:3000',
+};
+```
+
+#### 6. Database Migration Strategy
+**Issue**: No automated migration running strategy
+**Risk**: Database schema may become out of sync
+**Location**: Add migration scripts to `package.json`
+
+**Solution**:
+```json
+// apps/api/package.json
+{
+  "scripts": {
+    "dev": "bun run --hot src/index.ts",
+    "db:generate": "bunx drizzle-kit generate",
+    "db:migrate": "bunx drizzle-kit migrate",
+    "db:push": "bunx drizzle-kit push",
+    "db:studio": "bunx drizzle-kit studio"
+  }
+}
+```
+
+### Low Priority (Developer Experience)
+
+#### 7. Logging and Monitoring
+**Issue**: No structured logging for auth events
+**Risk**: Difficult to debug auth issues in production
+
+**Solution**:
+```typescript
+// Add logging middleware for auth events
+import { betterAuth } from "better-auth";
+
+export const auth = betterAuth({
+  // ... existing config
+  onRequest: async (request) => {
+    console.log(`Auth request: ${request.method} ${request.url}`);
+  },
+  onResponse: async (response) => {
+    if (!response.ok) {
+      console.error(`Auth error: ${response.status}`);
+    }
+  },
+  onError: async (error) => {
+    console.error('Auth error:', error.message);
+    // Send to monitoring service
+  },
+});
+```
+
+#### 8. Health Check Endpoint
+**Issue**: No way to verify auth system is operational
+**Risk**: Difficult to monitor system health
+
+**Solution**:
+```typescript
+// apps/api/src/index.ts
+app.get('/api/health', async (c) => {
+  try {
+    // Check database connection
+    await db.select().from(schema.user).limit(1);
+
+    return c.json({
+      status: 'healthy',
+      services: {
+        database: 'connected',
+        auth: 'operational',
+      },
+      timestamp: new Date().toISOString(),
+    });
+  } catch (error) {
+    return c.json({
+      status: 'unhealthy',
+      error: 'Database connection failed',
+    }, 503);
+  }
+});
+```
+
+#### 9. Testing Setup
+**Issue**: No tests for auth integration
+**Risk**: Regressions may go unnoticed
+
+**Solution**:
+```typescript
+// apps/api/src/__tests__/auth.test.ts
+import { describe, test, expect } from 'bun:test';
+import app from '../index';
+
+describe('Auth Integration', () => {
+  test('GET /api/auth/session returns 401 when not authenticated', async () => {
+    const response = await app.request('/api/auth/session');
+    expect(response.status).toBe(401);
+  });
+
+  test('POST /api/auth/sign-up validates email format', async () => {
+    const response = await app.request('/api/auth/sign-up', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        email: 'invalid-email',
+        password: 'password123',
+      }),
+    });
+    expect(response.status).toBe(400);
+  });
+});
+```
+
+## 📝 Documentation Needed
+
+1. **API Documentation**: Document all auth endpoints with request/response examples
+2. **Migration Guide**: Step-by-step guide for running migrations
+3. **Environment Setup**: Complete list of required env vars with examples
+4. **Frontend Integration**: Guide for integrating with Next.js frontend
+
+## ✅ What's Working Well
+
+- Clean separation of concerns with dedicated auth module
+- Proper use of Drizzle ORM with TypeScript
+- Generated schema follows Better Auth standards
+- Environment example file provided
+- Follows monorepo structure properly
+
+## 🚀 Next Steps
+
+1. **Immediate**: Apply high-priority security fixes before deploying
+2. **This Week**: Implement CORS and type exports for frontend integration
+3. **Next Sprint**: Add monitoring, health checks, and testing
+4. **Future**: Consider adding social auth providers and 2FA
+
+## 📊 Estimated Effort
+
+- High Priority items: 2-3 hours
+- Medium Priority items: 3-4 hours
+- Low Priority items: 4-6 hours
+- Documentation: 2-3 hours
+
+**Total estimated effort**: 11-16 hours
+
+---
+
+*Generated from PR #1 code review on 2025-09-21*


### PR DESCRIPTION
## Summary
- Integrated Better Auth for authentication in the API
- Configured Drizzle ORM adapter for PostgreSQL
- Set up authentication routes at `/api/auth/*`

## Changes
- ✨ Installed Better Auth package
- 🔧 Created auth configuration with Drizzle adapter
- 📊 Generated auth database schema with tables for users, sessions, accounts, and verification
- 🛣️ Mounted Better Auth routes in Hono server
- 📝 Added `.env.example` with required environment variables

## Next Steps
1. Copy `.env.example` to `.env` and configure database connection
2. Run database migrations with `bunx drizzle-kit generate` and `bunx drizzle-kit migrate`
3. Authentication endpoints are ready at:
   - `/api/auth/sign-up`
   - `/api/auth/sign-in`
   - `/api/auth/sign-out`
   - `/api/auth/session`

🤖 Generated with [Claude Code](https://claude.ai/code)